### PR TITLE
[FEATURE] 공통 Scaffold 및 하단 네비게이션 구현

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:ssogssog_flutter/app/routes.dart';
 import 'package:ssogssog_flutter/core/theme/app_theme.dart';
 
 class MyApp extends StatelessWidget {
@@ -6,14 +7,10 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
       title: '주식 쏙쏙',
       theme: AppTheme.lightTheme,
-      home: const Scaffold(
-        body: Center(
-          child: Text('시작 페이지'),
-        ),
-      ),
+      routerConfig: router,
     );
   }
 }

--- a/lib/app/routes.dart
+++ b/lib/app/routes.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+// GoRouter 인스턴스를 final 전역 변수로 둠
+final GoRouter router = GoRouter(
+  routes: <GoRoute>[
+    GoRoute( // routes에 GoRoute 등록
+      path: '/', // 루트 경로 진입 시 해당 화면 노출
+      builder: (BuildContext context, GoRouterState state) {
+        return const Scaffold( // 페이지 반환
+          body: Center(child: Text('Home Page')),
+        );
+      },
+    ),
+  ],
+);

--- a/lib/app/routes.dart
+++ b/lib/app/routes.dart
@@ -1,16 +1,51 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:ssogssog_flutter/core/widget/bottom_tap_scaffold.dart';
+import 'package:ssogssog_flutter/features/home/presentation/home_page.dart';
+import 'package:ssogssog_flutter/features/screener/presentation/screener_page.dart';
+import 'package:ssogssog_flutter/features/settings/presentation/settings_page.dart';
+import 'package:ssogssog_flutter/features/vault/presentation/vault_page.dart';
 
-// GoRouter 인스턴스를 final 전역 변수로 둠
+// 앱의 라우팅 설정을 담당하는 GoRouter 객체
+// 앱 전체의 라우팅 엔진!
 final GoRouter router = GoRouter(
-  routes: <GoRoute>[
-    GoRoute( // routes에 GoRoute 등록
-      path: '/', // 루트 경로 진입 시 해당 화면 노출
-      builder: (BuildContext context, GoRouterState state) {
-        return const Scaffold( // 페이지 반환
-          body: Center(child: Text('Home Page')),
-        );
+  // 앱의 초기 경로 설정
+  initialLocation: '/',
+
+  routes: [
+    // ShellRoute는 여러 라우트를 하나의 공통 UI(shell)로 감싸는 역할을 합니다.
+    // 여기서는 BottomTapScaffold를 공통 UI로 사용하여 하단 네비게이션을 구현합니다.
+    ShellRoute(
+      // builder는 공통 UI를 만드는 함수입니다.
+      // navigationShell은 자식 라우트(페이지)가 렌더링될 위젯입니다.
+      builder: (context, state, navigationShell) {
+        return BottomTapScaffold(child: navigationShell); // UI + child 연결
       },
+      // ex) HomePage 등 다른 페이지로 이동할 때 BottomTapScaffold(body:HomePage()) 가 아닌 저절로 UI 연결해줌
+
+      // ShellRoute에 의해 감싸질 자식 라우트 목록
+      routes: [
+        // 홈 화면 라우트
+        GoRoute(
+          path: '/',
+          builder: (context, state) => const HomePage(),
+        ),
+        // 조건검색 화면 라우트
+        GoRoute(
+          path: '/screener',
+          builder: (context, state) => const ScreenerPage(),
+        ),
+        // 보관함 화면 라우트
+        GoRoute(
+          path: '/vault',
+          builder: (context, state) => const VaultPage(),
+        ),
+        // 설정 화면 라우트
+        GoRoute(
+          path: '/settings',
+          builder: (context, state) => const SettingsPage(),
+        ),
+      ],
     ),
   ],
 );

--- a/lib/app/routes.dart
+++ b/lib/app/routes.dart
@@ -28,22 +28,30 @@ final GoRouter router = GoRouter(
         // 홈 화면 라우트
         GoRoute(
           path: '/',
-          builder: (context, state) => const HomePage(),
+          pageBuilder: (context, state) => const NoTransitionPage(
+            child: HomePage(),
+          ),
         ),
         // 조건검색 화면 라우트
         GoRoute(
           path: '/screener',
-          builder: (context, state) => const ScreenerPage(),
+          pageBuilder: (context, state) => const NoTransitionPage(
+            child: ScreenerPage(),
+          ),
         ),
         // 보관함 화면 라우트
         GoRoute(
           path: '/vault',
-          builder: (context, state) => const VaultPage(),
+          pageBuilder: (context, state) => const NoTransitionPage(
+            child: VaultPage(),
+          ),
         ),
         // 설정 화면 라우트
         GoRoute(
           path: '/settings',
-          builder: (context, state) => const SettingsPage(),
+          pageBuilder: (context, state) => const NoTransitionPage(
+            child: SettingsPage(),
+          ),
         ),
       ],
     ),

--- a/lib/core/widget/app_bottom_nav.dart
+++ b/lib/core/widget/app_bottom_nav.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:ssogssog_flutter/core/theme/app_theme.dart';
+
+/*
+AppBottomNav: 하단 탭 UI를 담당
+ */
+class AppBottomNav extends StatelessWidget {
+  // 하단 탭의 인덱스, 어떤 탭이 선택되어 있는지 (0 = 홈, 1 = 조건검색, 2 = 보관함, 3 = 설정)
+  final int currentIndex;
+  // 탭을 눌렀을 때 호출할 콜백 함수
+  final Function(int) onTap;
+
+  const AppBottomNav({
+    super.key,
+    required this.currentIndex,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return BottomNavigationBar(
+      currentIndex: currentIndex,
+      onTap: onTap,
+      type: BottomNavigationBarType.fixed,
+      backgroundColor: AppColors.white,
+      elevation: 5,
+
+      iconSize: 30,
+
+      // 아이콘 색상 설정
+      selectedItemColor: AppColors.primaryBlue, // 선택 시 색상
+      unselectedItemColor: AppColors.greyText,    // 미선택 시 색상
+
+      // 라벨 숨기기
+      showSelectedLabels: false,
+      showUnselectedLabels: false,
+
+      items: const [
+        BottomNavigationBarItem(
+          icon: Icon(Icons.home),
+          label: '홈',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.diamond),
+          label: '조건검색',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.folder),
+          label: '보관함',
+        ),
+        BottomNavigationBarItem(
+          icon: Icon(Icons.settings),
+          label: '설정',
+        ),
+      ],
+    );
+  }
+}

--- a/lib/core/widget/bottom_tap_scaffold.dart
+++ b/lib/core/widget/bottom_tap_scaffold.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:ssogssog_flutter/core/widget/app_bottom_nav.dart';
+
+/*
+BottomTapScaffold: 하단 네비게이션이 필요한 페이지들의 공통 레이아웃을 담당하는 위젯
+ */
+class BottomTapScaffold extends StatelessWidget {
+  final Widget child; // 실제 페이지 내용
+
+  const BottomTapScaffold({
+    required this.child,
+    Key? key,
+  }) : super(key: key);
+
+  // 현재 경로(location)를 기반으로 BottomNav의 현재 인덱스를 계산하는 함수
+  int _calculateCurrentIndex(BuildContext context) {
+    final String location = GoRouterState.of(context).uri.path;
+    if (location == '/screener') {
+      return 1;
+    } else if (location == '/vault') {
+      return 2;
+    } else if (location == '/settings') {
+      return 3;
+    }
+    return 0; // 기본값은 홈
+  }
+
+  // 하단 탭을 눌렀을 때 실행될 함수
+  void _onItemTapped(int index, BuildContext context) {
+    switch (index) {
+      case 0: // 홈
+        context.go('/');
+        break;
+      case 1: // 조건검색
+        context.go('/screener');
+        break;
+      case 2: // 보관함
+        context.go('/vault');
+        break;
+      case 3: // 설정
+        context.go('/settings');
+        break;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: child, // 실제 페이지 내용 ex) HomeScreen
+      // AppBottomNav에 현재 인덱스를 계산해서 넘겨주고, 탭 콜백을 연결
+      bottomNavigationBar: AppBottomNav(
+        currentIndex: _calculateCurrentIndex(context), // 현재 경로 기반 계산 값
+        onTap: (index) => _onItemTapped(index, context), // 클릭 시 라우팅 로직
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/home_page.dart
+++ b/lib/features/home/presentation/home_page.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text('홈 화면'),
+    );
+  }
+}

--- a/lib/features/screener/presentation/screener_page.dart
+++ b/lib/features/screener/presentation/screener_page.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class ScreenerPage extends StatelessWidget {
+  const ScreenerPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text('조건검색 화면'),
+    );
+  }
+}

--- a/lib/features/settings/presentation/settings_page.dart
+++ b/lib/features/settings/presentation/settings_page.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class SettingsPage extends StatelessWidget {
+  const SettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text('설정 화면'),
+    );
+  }
+}

--- a/lib/features/vault/presentation/vault_page.dart
+++ b/lib/features/vault/presentation/vault_page.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class VaultPage extends StatelessWidget {
+  const VaultPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text('보관함 화면'),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -75,6 +75,19 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      sha256: f02fd7d2a4dc512fec615529824fdd217fecb3a3d3de68360293a551f21634b3
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.8.1"
   leak_tracker:
     dependency: transitive
     description:
@@ -107,6 +120,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   matcher:
     dependency: transitive
     description:
@@ -210,4 +231,4 @@ packages:
     version: "15.0.2"
 sdks:
   dart: ">=3.10.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.22.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  go_router: ^14.2.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 📌 Issue number and Link
  closed #3 

## ✏️ Summary
공통으로 사용될 하단 탭 및 이동 로직 구현

## 📝 Changes
- app_bottom_nav 생성 (하단 탭 UI를 담당)
- bottom_tap_scaffold 생성 (하단 네비게이션이 필요한 페이지들의 공통 레이아웃을 담당하는 위젯)
- routes.dart : ShellRoute로 공통 UI 및 child 연결

## 🔎 PR Type

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot
<img width="497" height="932" alt="image" src="https://github.com/user-attachments/assets/ea6bdd10-5e59-4a57-9209-854bbc3f03d1" />
<img width="498" height="930" alt="image" src="https://github.com/user-attachments/assets/6c20daa6-32a5-4294-becc-c089b5fd5eed" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 하단 탭 네비게이션을 통한 4개 주요 화면 추가: 홈, 조건검색, 보관함, 설정
* 향상된 네비게이션 시스템으로 화면 간 이동 개선
* 앱 전체에 일관된 하단 네비게이션 인터페이스 적용

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->