### PR TITLE
[FEATURE] 필터 결과 화면 UI 구현

### DIFF
--- a/lib/app/routes.dart
+++ b/lib/app/routes.dart
@@ -3,50 +3,38 @@ import 'package:go_router/go_router.dart';
 import 'package:ssogssog_flutter/core/widget/bottom_tap_scaffold.dart';
 import 'package:ssogssog_flutter/features/home/presentation/home_page.dart';
 import 'package:ssogssog_flutter/features/screener/presentation/screener_page.dart';
+import 'package:ssogssog_flutter/features/screener/presentation/screener_result_page.dart'; // [추가]
 import 'package:ssogssog_flutter/features/settings/presentation/settings_page.dart';
 import 'package:ssogssog_flutter/features/vault/presentation/vault_page.dart';
 
 // 앱의 라우팅 설정을 담당하는 GoRouter 객체
-// 앱 전체의 라우팅 엔진!
 final GoRouter router = GoRouter(
-  // 앱의 초기 경로 설정
   initialLocation: '/',
-
   routes: [
-    // ShellRoute는 여러 라우트를 하나의 공통 UI(shell)로 감싸는 역할을 합니다.
-    // 여기서는 BottomTapScaffold를 공통 UI로 사용하여 하단 네비게이션을 구현합니다.
+    // 하단 탭이 있는 페이지들을 위한 ShellRoute
     ShellRoute(
-      // builder는 공통 UI를 만드는 함수입니다.
-      // navigationShell은 자식 라우트(페이지)가 렌더링될 위젯입니다.
       builder: (context, state, navigationShell) {
-        return BottomTapScaffold(child: navigationShell); // UI + child 연결
+        return BottomTapScaffold(child: navigationShell);
       },
-      // ex) HomePage 등 다른 페이지로 이동할 때 BottomTapScaffold(body:HomePage()) 가 아닌 저절로 UI 연결해줌
-
-      // ShellRoute에 의해 감싸질 자식 라우트 목록
       routes: [
-        // 홈 화면 라우트
         GoRoute(
           path: '/',
           pageBuilder: (context, state) => const NoTransitionPage(
             child: HomePage(),
           ),
         ),
-        // 조건검색 화면 라우트
         GoRoute(
           path: '/screener',
           pageBuilder: (context, state) => const NoTransitionPage(
             child: ScreenerPage(),
           ),
         ),
-        // 보관함 화면 라우트
         GoRoute(
           path: '/vault',
           pageBuilder: (context, state) => const NoTransitionPage(
             child: VaultPage(),
           ),
         ),
-        // 설정 화면 라우트
         GoRoute(
           path: '/settings',
           pageBuilder: (context, state) => const NoTransitionPage(
@@ -54,6 +42,12 @@ final GoRouter router = GoRouter(
           ),
         ),
       ],
+    ),
+
+    // 하단 탭이 없는 독립적인 페이지들
+    GoRoute(
+      path: '/screener/result',
+      builder: (context, state) => const ScreenerResultPage(),
     ),
   ],
 );

--- a/lib/features/screener/presentation/screener_page.dart
+++ b/lib/features/screener/presentation/screener_page.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart'; // [추가]
+import 'package:go_router/go_router.dart';
 import 'package:ssogssog_flutter/core/theme/app_theme.dart';
 import 'package:ssogssog_flutter/core/widget/common_app_bar.dart';
 import 'package:ssogssog_flutter/features/screener/presentation/widget/filter_chip_group.dart';
@@ -130,14 +130,15 @@ class ScreenerPage extends StatelessWidget {
           ),
         ],
       ),
-      // [핵심 수정] onPressed 콜백 함수에 페이지 이동 로직 추가
       bottomNavigationBar: _BottomApplyBar(
         label: '검색하기',
-        onPressed: () => context.go('/screener/result'),
+        //  context.go -> context.push
+        onPressed: () => context.push('/screener/result'), 
       ),
     );
   }
 }
+
 
 class _SectionCard extends StatelessWidget {
   final String title;
@@ -163,6 +164,7 @@ class _SectionCard extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(title, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w800)),
+
           if (subtitle != null) ...[
             const SizedBox(height: 6),
             Text(
@@ -175,6 +177,7 @@ class _SectionCard extends StatelessWidget {
               ),
             ),
           ],
+
           const SizedBox(height: 14),
           child,
         ],
@@ -182,6 +185,7 @@ class _SectionCard extends StatelessWidget {
     );
   }
 }
+
 
 class _BottomApplyBar extends StatelessWidget {
   final String label;

--- a/lib/features/screener/presentation/screener_page.dart
+++ b/lib/features/screener/presentation/screener_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart'; // [추가]
 import 'package:ssogssog_flutter/core/theme/app_theme.dart';
 import 'package:ssogssog_flutter/core/widget/common_app_bar.dart';
 import 'package:ssogssog_flutter/features/screener/presentation/widget/filter_chip_group.dart';
@@ -19,7 +20,6 @@ class ScreenerPage extends StatelessWidget {
       body: ListView(
         padding: const EdgeInsets.fromLTRB(_pageH, 16, _pageH, 120),
         children: [
-          // ✅ [추가] 상단 안내 멘트(배너)
           const _InfoBanner(
             text: '아래의 필터로 주식을 검색할 수 있습니다. 기준 값은 전일종가 기준으로 계산됩니다.',
           ),
@@ -27,7 +27,6 @@ class ScreenerPage extends StatelessWidget {
 
           _SectionCard(
             title: '기본 정보',
-            // ✅ [추가] 섹션별 안내 멘트
             subtitle: '아무것도 선택하지 않으면 전체 종목을 대상으로 합니다.',
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -131,18 +130,18 @@ class ScreenerPage extends StatelessWidget {
           ),
         ],
       ),
+      // [핵심 수정] onPressed 콜백 함수에 페이지 이동 로직 추가
       bottomNavigationBar: _BottomApplyBar(
         label: '검색하기',
-        onPressed: () {},
+        onPressed: () => context.go('/screener/result'),
       ),
     );
   }
 }
 
-
 class _SectionCard extends StatelessWidget {
   final String title;
-  final String? subtitle; // ✅ 추가
+  final String? subtitle;
   final Widget child;
 
   const _SectionCard({
@@ -164,8 +163,6 @@ class _SectionCard extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Text(title, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w800)),
-
-          // ✅ subtitle이 있을 때만 출력
           if (subtitle != null) ...[
             const SizedBox(height: 6),
             Text(
@@ -178,7 +175,6 @@ class _SectionCard extends StatelessWidget {
               ),
             ),
           ],
-
           const SizedBox(height: 14),
           child,
         ],
@@ -186,7 +182,6 @@ class _SectionCard extends StatelessWidget {
     );
   }
 }
-
 
 class _BottomApplyBar extends StatelessWidget {
   final String label;

--- a/lib/features/screener/presentation/screener_result_page.dart
+++ b/lib/features/screener/presentation/screener_result_page.dart
@@ -16,8 +16,7 @@ class ScreenerResultPage extends StatelessWidget {
         title: const Text('검색 결과'),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back_ios_new),
-          // go('/screener') 대신 pop()을 사용하여 자연스러운 뒤로가기 구현
-          onPressed: () => context.pop(), 
+          onPressed: () => context.pop(),
         ),
       ),
       backgroundColor: const Color(0xFFF6F7FB),
@@ -29,7 +28,14 @@ class ScreenerResultPage extends StatelessWidget {
               padding: const EdgeInsets.fromLTRB(20, 0, 20, 24),
               itemCount: 10,
               separatorBuilder: (_, __) => const SizedBox(height: 10),
-              itemBuilder: (_, __) => ScreenerResultCard(),
+              // [핵심 수정] ScreenerResultCard에 임시 데이터를 전달하여 오류 해결
+              itemBuilder: (_, __) => const ScreenerResultCard(
+                name: '큐로홀딩스',
+                code: '051780',
+                price: 1236,
+                changeRate: -29.97,
+                volume: 2517785,
+              ),
             ),
           ),
         ],

--- a/lib/features/screener/presentation/screener_result_page.dart
+++ b/lib/features/screener/presentation/screener_result_page.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:ssogssog_flutter/core/widget/common_app_bar.dart';
+
+class ScreenerResultPage extends StatelessWidget {
+  const ScreenerResultPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO: 실제 필터링된 데이터를 받아서 처리하기
+    const int resultCount = 1731;
+
+    return const Scaffold(
+      appBar: CommonAppBar(title: '검색 결과'),
+      body: Column(
+        children: [
+          // TODO: 1. 현재 필터 보기 버튼
+          // TODO: 2. 검색 결과 요약 텍스트
+          // TODO: 3. 결과 리스트
+          Center(
+            child: Text('검색 결과가 여기에 표시됩니다.'),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/screener/presentation/screener_result_page.dart
+++ b/lib/features/screener/presentation/screener_result_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:ssogssog_flutter/core/theme/app_theme.dart';
-import 'package:ssogssog_flutter/core/widget/common_app_bar.dart';
-import 'package:ssogssog_flutter/features/screener/presentation/widget/applied_filter_bottom_sheet.dart'; // [추가]
+import 'package:ssogssog_flutter/features/screener/presentation/widget/applied_filter_bottom_sheet.dart';
 import 'package:ssogssog_flutter/features/screener/presentation/widget/screener_result_card.dart';
 
 class ScreenerResultPage extends StatelessWidget {
@@ -12,11 +12,17 @@ class ScreenerResultPage extends StatelessWidget {
     const int resultCount = 1731;
 
     return Scaffold(
-      appBar: const CommonAppBar(title: '검색 결과'),
+      appBar: AppBar(
+        title: const Text('검색 결과'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios_new),
+          // go('/screener') 대신 pop()을 사용하여 자연스러운 뒤로가기 구현
+          onPressed: () => context.pop(), 
+        ),
+      ),
       backgroundColor: const Color(0xFFF6F7FB),
       body: Column(
         children: [
-          // [핵심 수정] buildContext를 전달하기 위해 메서드 호출 부분 변경
           _buildCurrentFilterHeader(context, resultCount),
           Expanded(
             child: ListView.separated(
@@ -43,10 +49,9 @@ class ScreenerResultPage extends StatelessWidget {
             child: InkWell(
               borderRadius: BorderRadius.circular(16),
               onTap: () {
-                // [핵심 수정] 바텀 시트를 띄우는 코드 추가
                 showModalBottomSheet(
                   context: context,
-                  isScrollControlled: true, // true로 설정해야 키보드 등에 의해 가려지지 않음
+                  isScrollControlled: true,
                   shape: const RoundedRectangleBorder(
                     borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
                   ),

--- a/lib/features/screener/presentation/screener_result_page.dart
+++ b/lib/features/screener/presentation/screener_result_page.dart
@@ -15,28 +15,14 @@ class ScreenerResultPage extends StatelessWidget {
       appBar: const CommonAppBar(title: '검색 결과'),
       backgroundColor: const Color(0xFFF6F7FB), // 배경색 추가
       body: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // 1. 현재 필터 보기 버튼
-          _buildCurrentFilterButton(),
-
-          // 2. 검색 결과 요약 텍스트
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-            child: Text(
-              '전일종가 기준으로 총 $resultCount건이 검색되었습니다.',
-              style: const TextStyle(color: AppColors.greyText, fontSize: 13),
-            ),
-          ),
-
-          // 3. 결과 리스트
+          _buildCurrentFilterHeader(resultCount),
           Expanded(
-            child: ListView.builder(
-              padding: const EdgeInsets.only(bottom: 24), // 리스트 하단 여백
-              itemCount: 10, // 임시로 10개 항목 표시
-              itemBuilder: (context, index) {
-                return const ScreenerResultCard();
-              },
+            child: ListView.separated(
+              padding: const EdgeInsets.fromLTRB(20, 0, 20, 24),
+              itemCount: 10,
+              separatorBuilder: (_, __) => const SizedBox(height: 10),
+              itemBuilder: (_, __) => ScreenerResultCard(),
             ),
           ),
         ],
@@ -45,25 +31,57 @@ class ScreenerResultPage extends StatelessWidget {
   }
 
   // '현재 필터 보기' 버튼 위젯
-  Widget _buildCurrentFilterButton() {
+  Widget _buildCurrentFilterHeader(int resultCount) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(20, 16, 20, 0),
-      child: OutlinedButton.icon(
-        onPressed: () {
-          // TODO: 현재 필터 상세 보기 기능
-        },
-        icon: const Icon(Icons.filter_list, size: 20),
-        label: const Text('현재 필터 보기'),
-        style: OutlinedButton.styleFrom(
-          minimumSize: const Size(double.infinity, 50), // 버튼의 최소 크기(너비, 높이)
-          foregroundColor: Colors.black87,
-          backgroundColor: Colors.white,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(12),
+      padding: const EdgeInsets.fromLTRB(20, 16, 20, 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Material(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(16),
+            child: InkWell(
+              borderRadius: BorderRadius.circular(16),
+              onTap: () {
+                // TODO: 현재 필터 bottom sheet
+              },
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                    horizontal: 14, vertical: 14),
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(16),
+                  border: Border.all(color: const Color(0xFFEDEFF5)),
+                ),
+                child: Row(
+                  children: [
+                    const Icon(Icons.tune_rounded, size: 18,
+                        color: AppColors.primaryBlue),
+                    const SizedBox(width: 10),
+                    const Expanded(
+                      child: Text(
+                        '현재 필터 보기',
+                        style: TextStyle(
+                            fontSize: 14.5, fontWeight: FontWeight.w800),
+                      ),
+                    ),
+                    const Icon(
+                        Icons.chevron_right_rounded, color: Color(0xFF8B93A1)),
+                  ],
+                ),
+              ),
+            ),
           ),
-          side: BorderSide(color: Colors.grey[300]!),
-        ),
+          const SizedBox(height: 10),
+          Text(
+            '전일종가 기준으로 총 $resultCount건이 검색되었습니다.',
+            style: const TextStyle(color: Color(0xFF8B93A1),
+                fontSize: 12.5,
+                fontWeight: FontWeight.w600),
+          ),
+        ],
       ),
     );
   }
 }
+
+

--- a/lib/features/screener/presentation/screener_result_page.dart
+++ b/lib/features/screener/presentation/screener_result_page.dart
@@ -1,25 +1,68 @@
 import 'package:flutter/material.dart';
+import 'package:ssogssog_flutter/core/theme/app_theme.dart';
 import 'package:ssogssog_flutter/core/widget/common_app_bar.dart';
+import 'package:ssogssog_flutter/features/screener/presentation/widget/screener_result_card.dart';
 
 class ScreenerResultPage extends StatelessWidget {
   const ScreenerResultPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    // TODO: 실제 필터링된 데이터를 받아서 처리하기
+    // TODO: 실제 필터링된 데이터를 받아서 처리해야 합니다.
     const int resultCount = 1731;
 
-    return const Scaffold(
-      appBar: CommonAppBar(title: '검색 결과'),
+    return Scaffold(
+      appBar: const CommonAppBar(title: '검색 결과'),
+      backgroundColor: const Color(0xFFF6F7FB), // 배경색 추가
       body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // TODO: 1. 현재 필터 보기 버튼
-          // TODO: 2. 검색 결과 요약 텍스트
-          // TODO: 3. 결과 리스트
-          Center(
-            child: Text('검색 결과가 여기에 표시됩니다.'),
-          )
+          // 1. 현재 필터 보기 버튼
+          _buildCurrentFilterButton(),
+
+          // 2. 검색 결과 요약 텍스트
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+            child: Text(
+              '전일종가 기준으로 총 $resultCount건이 검색되었습니다.',
+              style: const TextStyle(color: AppColors.greyText, fontSize: 13),
+            ),
+          ),
+
+          // 3. 결과 리스트
+          Expanded(
+            child: ListView.builder(
+              padding: const EdgeInsets.only(bottom: 24), // 리스트 하단 여백
+              itemCount: 10, // 임시로 10개 항목 표시
+              itemBuilder: (context, index) {
+                return const ScreenerResultCard();
+              },
+            ),
+          ),
         ],
+      ),
+    );
+  }
+
+  // '현재 필터 보기' 버튼 위젯
+  Widget _buildCurrentFilterButton() {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 16, 20, 0),
+      child: OutlinedButton.icon(
+        onPressed: () {
+          // TODO: 현재 필터 상세 보기 기능
+        },
+        icon: const Icon(Icons.filter_list, size: 20),
+        label: const Text('현재 필터 보기'),
+        style: OutlinedButton.styleFrom(
+          minimumSize: const Size(double.infinity, 50), // 버튼의 최소 크기(너비, 높이)
+          foregroundColor: Colors.black87,
+          backgroundColor: Colors.white,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+          side: BorderSide(color: Colors.grey[300]!),
+        ),
       ),
     );
   }

--- a/lib/features/screener/presentation/screener_result_page.dart
+++ b/lib/features/screener/presentation/screener_result_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:ssogssog_flutter/core/theme/app_theme.dart';
 import 'package:ssogssog_flutter/core/widget/common_app_bar.dart';
+import 'package:ssogssog_flutter/features/screener/presentation/widget/applied_filter_bottom_sheet.dart'; // [추가]
 import 'package:ssogssog_flutter/features/screener/presentation/widget/screener_result_card.dart';
 
 class ScreenerResultPage extends StatelessWidget {
@@ -8,15 +9,15 @@ class ScreenerResultPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // TODO: 실제 필터링된 데이터를 받아서 처리해야 합니다.
     const int resultCount = 1731;
 
     return Scaffold(
       appBar: const CommonAppBar(title: '검색 결과'),
-      backgroundColor: const Color(0xFFF6F7FB), // 배경색 추가
+      backgroundColor: const Color(0xFFF6F7FB),
       body: Column(
         children: [
-          _buildCurrentFilterHeader(resultCount),
+          // [핵심 수정] buildContext를 전달하기 위해 메서드 호출 부분 변경
+          _buildCurrentFilterHeader(context, resultCount),
           Expanded(
             child: ListView.separated(
               padding: const EdgeInsets.fromLTRB(20, 0, 20, 24),
@@ -30,8 +31,7 @@ class ScreenerResultPage extends StatelessWidget {
     );
   }
 
-  // '현재 필터 보기' 버튼 위젯
-  Widget _buildCurrentFilterHeader(int resultCount) {
+  Widget _buildCurrentFilterHeader(BuildContext context, int resultCount) {
     return Padding(
       padding: const EdgeInsets.fromLTRB(20, 16, 20, 12),
       child: Column(
@@ -43,29 +43,33 @@ class ScreenerResultPage extends StatelessWidget {
             child: InkWell(
               borderRadius: BorderRadius.circular(16),
               onTap: () {
-                // TODO: 현재 필터 bottom sheet
+                // [핵심 수정] 바텀 시트를 띄우는 코드 추가
+                showModalBottomSheet(
+                  context: context,
+                  isScrollControlled: true, // true로 설정해야 키보드 등에 의해 가려지지 않음
+                  shape: const RoundedRectangleBorder(
+                    borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+                  ),
+                  builder: (_) => const AppliedFilterBottomSheet(),
+                );
               },
               child: Container(
-                padding: const EdgeInsets.symmetric(
-                    horizontal: 14, vertical: 14),
+                padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 14),
                 decoration: BoxDecoration(
                   borderRadius: BorderRadius.circular(16),
                   border: Border.all(color: const Color(0xFFEDEFF5)),
                 ),
                 child: Row(
                   children: [
-                    const Icon(Icons.tune_rounded, size: 18,
-                        color: AppColors.primaryBlue),
+                    const Icon(Icons.tune_rounded, size: 18, color: AppColors.primaryBlue),
                     const SizedBox(width: 10),
                     const Expanded(
                       child: Text(
                         '현재 필터 보기',
-                        style: TextStyle(
-                            fontSize: 14.5, fontWeight: FontWeight.w800),
+                        style: TextStyle(fontSize: 14.5, fontWeight: FontWeight.w800),
                       ),
                     ),
-                    const Icon(
-                        Icons.chevron_right_rounded, color: Color(0xFF8B93A1)),
+                    const Icon(Icons.chevron_right_rounded, color: Color(0xFF8B93A1)),
                   ],
                 ),
               ),
@@ -74,14 +78,10 @@ class ScreenerResultPage extends StatelessWidget {
           const SizedBox(height: 10),
           Text(
             '전일종가 기준으로 총 $resultCount건이 검색되었습니다.',
-            style: const TextStyle(color: Color(0xFF8B93A1),
-                fontSize: 12.5,
-                fontWeight: FontWeight.w600),
+            style: const TextStyle(color: Color(0xFF8B93A1), fontSize: 12.5, fontWeight: FontWeight.w600),
           ),
         ],
       ),
     );
   }
 }
-
-

--- a/lib/features/screener/presentation/widget/applied_filter_bottom_sheet.dart
+++ b/lib/features/screener/presentation/widget/applied_filter_bottom_sheet.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:ssogssog_flutter/core/theme/app_theme.dart';
+
+/// '적용된 필터'의 상세 내용을 보여주는 바텀 시트 위젯
+class AppliedFilterBottomSheet extends StatelessWidget {
+  const AppliedFilterBottomSheet({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO: 실제 적용된 필터 목록을 외부에서 받아와야 합니다.
+    final List<String> appliedFilters = [
+      '1만~3만원', '중형주', 'PER 0~10배', 'ROE 전체',
+      '부채비율 0~200%', '매출액 성장률 10~100%', '순이익 성장률 전체',
+      '외국인 보유율 30~70%'
+    ];
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 20, 20, 32),
+      child: Column(
+        mainAxisSize: MainAxisSize.min, // 콘텐츠 크기만큼만 높이 차지
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 1. 제목과 닫기 버튼
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text('적용된 필터', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+              IconButton(
+                onPressed: () => Navigator.pop(context), // 바텀 시트 닫기
+                icon: const Icon(Icons.close),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          const Text('현재 조건을 저장해 빠르게 불러올 수 있습니다.', style: TextStyle(color: AppColors.greyText)),
+          const SizedBox(height: 24),
+
+          // 2. 적용된 필터 칩 목록
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: appliedFilters.map((filter) => _buildFilterChip(filter)).toList(),
+          ),
+          const SizedBox(height: 32),
+
+          // 3. 하단 버튼
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: () {
+                    Navigator.pop(context); // 바텀 시트 닫고
+                    context.go('/screener'); // 필터 설정 페이지로 이동
+                  },
+                  style: OutlinedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    side: BorderSide(color: Colors.grey[300]!),
+                  ),
+                  child: const Text('필터 수정'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: () {
+                    // TODO: 이 조건 저장 기능
+                  },
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 14),
+                    backgroundColor: AppColors.primaryBlue,
+                    foregroundColor: Colors.white,
+                  ),
+                  child: const Text('이 조건 저장'),
+                ),
+              ),
+            ],
+          )
+        ],
+      ),
+    );
+  }
+
+  // 필터 칩을 만드는 위젯
+  Widget _buildFilterChip(String label) {
+    return Chip(
+      label: Text(label, style: const TextStyle(color: AppColors.greyText, fontWeight: FontWeight.w500)),
+      deleteIcon: const Icon(Icons.close, size: 14),
+      onDeleted: () {
+        // TODO: 개별 필터 삭제 로직
+      },
+      backgroundColor: Colors.grey[200],
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+        side: const BorderSide(color: Colors.transparent),
+      ),
+    );
+  }
+}

--- a/lib/features/screener/presentation/widget/applied_filter_bottom_sheet.dart
+++ b/lib/features/screener/presentation/widget/applied_filter_bottom_sheet.dart
@@ -50,14 +50,13 @@ class AppliedFilterBottomSheet extends StatelessWidget {
               Expanded(
                 child: OutlinedButton(
                   onPressed: () {
-                    Navigator.pop(context); // 바텀 시트 닫고
-                    context.go('/screener'); // 필터 설정 페이지로 이동
+                    context.pop(); // 1. 바텀 시트를 닫음
+                    context.pop(); // 2. 검색 결과 페이지를 닫아 필터 설정 페이지로 돌아감
                   },
                   style: OutlinedButton.styleFrom(
                     padding: const EdgeInsets.symmetric(vertical: 14),
                     side: BorderSide(color: Colors.grey[300]!),
                   ),
-                  // 텍스트에 bold 스타일 추가
                   child: const Text('필터 수정', style: TextStyle(fontWeight: FontWeight.bold)),
                 ),
               ),

--- a/lib/features/screener/presentation/widget/applied_filter_bottom_sheet.dart
+++ b/lib/features/screener/presentation/widget/applied_filter_bottom_sheet.dart
@@ -57,7 +57,8 @@ class AppliedFilterBottomSheet extends StatelessWidget {
                     padding: const EdgeInsets.symmetric(vertical: 14),
                     side: BorderSide(color: Colors.grey[300]!),
                   ),
-                  child: const Text('필터 수정'),
+                  // 텍스트에 bold 스타일 추가
+                  child: const Text('필터 수정', style: TextStyle(fontWeight: FontWeight.bold)),
                 ),
               ),
               const SizedBox(width: 12),
@@ -71,7 +72,7 @@ class AppliedFilterBottomSheet extends StatelessWidget {
                     backgroundColor: AppColors.primaryBlue,
                     foregroundColor: Colors.white,
                   ),
-                  child: const Text('이 조건 저장'),
+                  child: const Text('이 조건 저장', style: TextStyle(fontWeight: FontWeight.bold)),
                 ),
               ),
             ],

--- a/lib/features/screener/presentation/widget/screener_result_card.dart
+++ b/lib/features/screener/presentation/widget/screener_result_card.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:ssogssog_flutter/core/theme/app_theme.dart';
+
+class ScreenerResultCard extends StatelessWidget {
+  const ScreenerResultCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16.0),
+      margin: const EdgeInsets.symmetric(horizontal: 20, vertical: 6),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 10,
+          )
+        ],
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          // 왼쪽: 종목 정보
+          const Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('큐로홀딩스', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+                SizedBox(height: 4),
+                Text('051780', style: TextStyle(fontSize: 13, color: AppColors.greyText)),
+                // TODO: 여기에 태그가 들어올 수 있습니다.
+              ],
+            ),
+          ),
+          // 오른쪽: 가격 정보 및 즐겨찾기
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              const Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Text('1,236', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                  SizedBox(height: 4),
+                  Text('+29.97%', style: TextStyle(fontSize: 14, color: Colors.red, fontWeight: FontWeight.w600)),
+                  SizedBox(height: 4),
+                  Row(
+                    children: [
+                      Icon(Icons.bar_chart, size: 16, color: AppColors.greyText),
+                      SizedBox(width: 4),
+                      Text('2,517,785', style: TextStyle(color: AppColors.greyText, fontSize: 12)),
+                    ],
+                  )
+                ],
+              ),
+              const SizedBox(width: 16),
+              IconButton(
+                onPressed: () {},
+                icon: const Icon(Icons.star_border, color: AppColors.greyText),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/screener/presentation/widget/screener_result_card.dart
+++ b/lib/features/screener/presentation/widget/screener_result_card.dart
@@ -2,66 +2,128 @@ import 'package:flutter/material.dart';
 import 'package:ssogssog_flutter/core/theme/app_theme.dart';
 
 class ScreenerResultCard extends StatelessWidget {
-  const ScreenerResultCard({super.key});
+  ScreenerResultCard({super.key});
+
+  // 임시 데이터 (나중에 모델로 주입)
+  final String name = '큐로홀딩스';
+  final String code = '051780';
+  final int price = 1236;
+  final double changeRate = 29.97; // +면 상승, -면 하락
+  final int volume = 2517785;
+
+  String _fmtInt(int n) {
+    final s = n.toString();
+    final buf = StringBuffer();
+    for (int i = 0; i < s.length; i++) {
+      final idxFromEnd = s.length - i;
+      buf.write(s[i]);
+      if (idxFromEnd > 1 && idxFromEnd % 3 == 1) buf.write(',');
+    }
+    return buf.toString();
+  }
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(16.0),
-      margin: const EdgeInsets.symmetric(horizontal: 20, vertical: 6),
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(16),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withOpacity(0.05),
-            blurRadius: 10,
-          )
-        ],
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: [
-          // 왼쪽: 종목 정보
-          const Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text('큐로홀딩스', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
-                SizedBox(height: 4),
-                Text('051780', style: TextStyle(fontSize: 13, color: AppColors.greyText)),
-                // TODO: 여기에 태그가 들어올 수 있습니다.
-              ],
-            ),
+    final isUp = changeRate >= 0;
+    final rateColor = isUp ? const Color(0xFFE53935) : const Color(0xFF1565C0);
+    final rateText = '${isUp ? '+' : ''}${changeRate.toStringAsFixed(2)}%';
+
+    return Material(
+      color: Colors.white,
+      borderRadius: BorderRadius.circular(18),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(18),
+        onTap: () {
+          // TODO: 종목 상세
+        },
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(18),
+            border: Border.all(color: const Color(0xFFEDEFF5)),
           ),
-          // 오른쪽: 가격 정보 및 즐겨찾기
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.end,
+          child: Row(
             children: [
-              const Column(
+              // 좌측: 종목 정보
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      name,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w800, // w900 -> w800
+                        color: Color(0xFF111318),
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      code,
+                      style: const TextStyle(
+                        fontSize: 12.5,
+                        color: Color(0xFF8B93A1),
+                        fontWeight: FontWeight.w600, // w700 -> w600 (살짝 부드럽게)
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              // 우측: 가격/등락/거래량
+              Column(
                 crossAxisAlignment: CrossAxisAlignment.end,
                 children: [
-                  Text('1,236', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-                  SizedBox(height: 4),
-                  Text('+29.97%', style: TextStyle(fontSize: 14, color: Colors.red, fontWeight: FontWeight.w600)),
-                  SizedBox(height: 4),
+                  Text(
+                    '${_fmtInt(price)}원',
+                    style: const TextStyle(
+                      fontSize: 17,
+                      fontWeight: FontWeight.w800, // w900 -> w800
+                      color: Color(0xFF111318),
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+
+                  Text(
+                    rateText,
+                    style: TextStyle(
+                      fontSize: 13.5,
+                      color: rateColor,
+                      fontWeight: FontWeight.w800, // w900 -> w800
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+
                   Row(
+                    mainAxisSize: MainAxisSize.min,
                     children: [
-                      Icon(Icons.bar_chart, size: 16, color: AppColors.greyText),
-                      SizedBox(width: 4),
-                      Text('2,517,785', style: TextStyle(color: AppColors.greyText, fontSize: 12)),
+                      const Icon(Icons.bar_chart_rounded, size: 16, color: Color(0xFF8B93A1)),
+                      const SizedBox(width: 4),
+                      Text(
+                        '거래량 ${_fmtInt(volume)}',
+                        style: const TextStyle(
+                          fontSize: 12,
+                          color: Color(0xFF8B93A1),
+                          fontWeight: FontWeight.w600, // w700 -> w600
+                        ),
+                      ),
                     ],
-                  )
+                  ),
                 ],
               ),
-              const SizedBox(width: 16),
+
+              const SizedBox(width: 10),
+
               IconButton(
                 onPressed: () {},
-                icon: const Icon(Icons.star_border, color: AppColors.greyText),
+                icon: const Icon(Icons.star_border_rounded, color: Color(0xFF8B93A1)),
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(minWidth: 40, minHeight: 40),
+                splashRadius: 22,
               ),
             ],
           ),
-        ],
+        ),
       ),
     );
   }

--- a/lib/features/screener/presentation/widget/screener_result_card.dart
+++ b/lib/features/screener/presentation/widget/screener_result_card.dart
@@ -2,15 +2,22 @@ import 'package:flutter/material.dart';
 import 'package:ssogssog_flutter/core/theme/app_theme.dart';
 
 class ScreenerResultCard extends StatelessWidget {
-  ScreenerResultCard({super.key});
+  final String name;
+  final String code;
+  final int price;
+  final double changeRate;
+  final int volume;
 
-  // 임시 데이터 (나중에 모델로 주입)
-  final String name = '큐로홀딩스';
-  final String code = '051780';
-  final int price = 1236;
-  final double changeRate = 29.97; // +면 상승, -면 하락
-  final int volume = 2517785;
+  const ScreenerResultCard({
+    super.key,
+    required this.name,
+    required this.code,
+    required this.price,
+    required this.changeRate,
+    required this.volume,
+  });
 
+  // 숫자를 포맷하는 private 헬퍼 함수
   String _fmtInt(int n) {
     final s = n.toString();
     final buf = StringBuffer();
@@ -53,7 +60,7 @@ class ScreenerResultCard extends StatelessWidget {
                       name,
                       style: const TextStyle(
                         fontSize: 16,
-                        fontWeight: FontWeight.w800, // w900 -> w800
+                        fontWeight: FontWeight.w800,
                         color: Color(0xFF111318),
                       ),
                     ),
@@ -63,7 +70,7 @@ class ScreenerResultCard extends StatelessWidget {
                       style: const TextStyle(
                         fontSize: 12.5,
                         color: Color(0xFF8B93A1),
-                        fontWeight: FontWeight.w600, // w700 -> w600 (살짝 부드럽게)
+                        fontWeight: FontWeight.w600,
                       ),
                     ),
                   ],
@@ -78,22 +85,20 @@ class ScreenerResultCard extends StatelessWidget {
                     '${_fmtInt(price)}원',
                     style: const TextStyle(
                       fontSize: 17,
-                      fontWeight: FontWeight.w800, // w900 -> w800
+                      fontWeight: FontWeight.w800,
                       color: Color(0xFF111318),
                     ),
                   ),
                   const SizedBox(height: 6),
-
                   Text(
                     rateText,
                     style: TextStyle(
                       fontSize: 13.5,
                       color: rateColor,
-                      fontWeight: FontWeight.w800, // w900 -> w800
+                      fontWeight: FontWeight.w800,
                     ),
                   ),
                   const SizedBox(height: 6),
-
                   Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
@@ -104,7 +109,7 @@ class ScreenerResultCard extends StatelessWidget {
                         style: const TextStyle(
                           fontSize: 12,
                           color: Color(0xFF8B93A1),
-                          fontWeight: FontWeight.w600, // w700 -> w600
+                          fontWeight: FontWeight.w600,
                         ),
                       ),
                     ],


### PR DESCRIPTION
## 📌 Issue number and Link
  closed #9 

## ✏️ Summary
- 필터 결과 화면 UI 구현
- 적용된 필터 화면 UI 구현

## 📝 Changes
- 필터 검색 결과 화면의 기본 UI를 구현
- 현재 필터 보기 버튼 클릭 시, 적용된 필터 목록을 보여주는 UI를 추가
- 바텀시트 내 필터 수정 버튼을 통해 필터 설정 화면으로 다시 돌아갈 수 있도록 router 연결
- 검색 결과 화면에서 뒤로가기 버튼을 추가
- 
## 🔎 PR Type
<!-- 해당되는 항목에 [x]를 표시해주세요. -->

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot
<img width="414" height="859" alt="image" src="https://github.com/user-attachments/assets/cf6fb76c-2b90-491b-81a7-8270258a28d3" />
<img width="408" height="867" alt="image" src="https://github.com/user-attachments/assets/87e104a3-1f91-4906-aaf2-3de4e1b6d5d5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **스크리너 결과 페이지** - 검색 결과를 표시하는 새로운 전용 페이지 추가
* **필터 관리 기능** - 적용된 필터를 바텀시트에서 확인하고 수정할 수 있는 UI 제공
* **종목 결과 카드** - 종목명, 코드, 가격, 변동률, 거래량을 보여주는 결과 카드 위젯 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->