### PR TITLE
[FEATURE] 종목 상세 페이지-개요 UI 구현

### DIFF
--- a/lib/app/routes.dart
+++ b/lib/app/routes.dart
@@ -3,15 +3,14 @@ import 'package:go_router/go_router.dart';
 import 'package:ssogssog_flutter/core/widget/bottom_tap_scaffold.dart';
 import 'package:ssogssog_flutter/features/home/presentation/home_page.dart';
 import 'package:ssogssog_flutter/features/screener/presentation/screener_page.dart';
-import 'package:ssogssog_flutter/features/screener/presentation/screener_result_page.dart'; // [추가]
+import 'package:ssogssog_flutter/features/screener/presentation/screener_result_page.dart';
 import 'package:ssogssog_flutter/features/settings/presentation/settings_page.dart';
+import 'package:ssogssog_flutter/features/stock_detail/presentation/stock_detail_page.dart';
 import 'package:ssogssog_flutter/features/vault/presentation/vault_page.dart';
 
-// 앱의 라우팅 설정을 담당하는 GoRouter 객체
 final GoRouter router = GoRouter(
   initialLocation: '/',
   routes: [
-    // 하단 탭이 있는 페이지들을 위한 ShellRoute
     ShellRoute(
       builder: (context, state, navigationShell) {
         return BottomTapScaffold(child: navigationShell);
@@ -19,35 +18,57 @@ final GoRouter router = GoRouter(
       routes: [
         GoRoute(
           path: '/',
-          pageBuilder: (context, state) => const NoTransitionPage(
-            child: HomePage(),
+          pageBuilder: (context, state) => NoTransitionPage(
+            child: const HomePage(),
           ),
         ),
         GoRoute(
           path: '/screener',
-          pageBuilder: (context, state) => const NoTransitionPage(
-            child: ScreenerPage(),
+          pageBuilder: (context, state) => NoTransitionPage(
+            child: const ScreenerPage(),
           ),
         ),
         GoRoute(
           path: '/vault',
-          pageBuilder: (context, state) => const NoTransitionPage(
-            child: VaultPage(),
+          pageBuilder: (context, state) => NoTransitionPage(
+            child: const VaultPage(),
           ),
         ),
         GoRoute(
           path: '/settings',
-          pageBuilder: (context, state) => const NoTransitionPage(
-            child: SettingsPage(),
+          pageBuilder: (context, state) => NoTransitionPage(
+            child: const SettingsPage(),
           ),
         ),
       ],
     ),
-
-    // 하단 탭이 없는 독립적인 페이지들
     GoRoute(
       path: '/screener/result',
       builder: (context, state) => const ScreenerResultPage(),
     ),
+    // 종목 상세 페이지를 위한 동적 라우트
+    GoRoute(
+      path: '/stock/:stockCode', // ':'는 이 부분이 변수임을 의미
+      builder: (context, state) {
+        // URL에서 stockCode 값을 추출
+        final String stockCode = state.pathParameters['stockCode']!;
+        return StockDetailPage(stockCode: stockCode);
+      },
+    ),
   ],
 );
+
+// 화면 전환 애니메이션을 없애기 위한 CustomTransitionPage
+class NoTransitionPage<T> extends CustomTransitionPage<T> {
+  NoTransitionPage({
+    required super.child,
+    super.name,
+    super.arguments,
+    super.restorationId,
+    super.key,
+  }) : super(
+          transitionsBuilder: (_, __, ___, child) => child,
+          transitionDuration: Duration.zero,
+          reverseTransitionDuration: Duration.zero,
+        );
+}

--- a/lib/features/screener/presentation/widget/screener_result_card.dart
+++ b/lib/features/screener/presentation/widget/screener_result_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:ssogssog_flutter/core/theme/app_theme.dart';
 
 class ScreenerResultCard extends StatelessWidget {
@@ -17,7 +18,6 @@ class ScreenerResultCard extends StatelessWidget {
     required this.volume,
   });
 
-  // 숫자를 포맷하는 private 헬퍼 함수
   String _fmtInt(int n) {
     final s = n.toString();
     final buf = StringBuffer();
@@ -41,7 +41,8 @@ class ScreenerResultCard extends StatelessWidget {
       child: InkWell(
         borderRadius: BorderRadius.circular(18),
         onTap: () {
-          // TODO: 종목 상세
+          // [핵심 수정] 탭하면 종목 코드를 가지고 상세 페이지로 이동
+          context.push('/stock/$code');
         },
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),

--- a/lib/features/stock_detail/presentation/stock_detail_page.dart
+++ b/lib/features/stock_detail/presentation/stock_detail_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/overview_tab.dart'; // [추가]
+import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/overview_tab.dart';
 
 class StockDetailPage extends StatefulWidget {
-  final String stockCode; // 라우터로부터 전달받을 종목 코드
+  final String stockCode;
 
   const StockDetailPage({super.key, required this.stockCode});
 
@@ -11,18 +11,26 @@ class StockDetailPage extends StatefulWidget {
 }
 
 class _StockDetailPageState extends State<StockDetailPage> {
-  int _selectedTabIndex = 0; // 현재 선택된 하단 탭 인덱스 (0: 개요)
+  int _selectedTabIndex = 0;
+  final List<String> tabNames = ['개요', '일별시세', '재무', '뉴스/공시'];
 
   @override
   Widget build(BuildContext context) {
+    // TODO: 실제 종목 데이터를 stockCode를 이용해 가져와야 함
+    const String stockName = "큐로홀딩스";
+
     return Scaffold(
       appBar: AppBar(
-        // 페이지 제목 없이 뒤로가기 버튼만 있는 깔끔한 AppBar
+        // [핵심 수정] AppBar에 종목명만 표시하도록 변경
+        title: Text(
+          '$stockName (${widget.stockCode})',
+          style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+        ),
+        titleSpacing: 0, // 타이틀의 왼쪽 기본 여백 제거
       ),
       body: IndexedStack(
         index: _selectedTabIndex,
         children: const [
-          // [핵심 수정] '개요' 탭의 내용을 OverviewTab 위젯으로 교체
           OverviewTab(),
           Center(child: Text('일별시세 탭 콘텐츠')),
           Center(child: Text('재무 탭 콘텐츠')),
@@ -33,7 +41,6 @@ class _StockDetailPageState extends State<StockDetailPage> {
     );
   }
 
-  // 하단 탭 네비게이션 바 위젯
   Widget _buildBottomNavigationBar() {
     return BottomNavigationBar(
       currentIndex: _selectedTabIndex,

--- a/lib/features/stock_detail/presentation/stock_detail_page.dart
+++ b/lib/features/stock_detail/presentation/stock_detail_page.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+class StockDetailPage extends StatefulWidget {
+  final String stockCode; // 라우터로부터 전달받을 종목 코드
+
+  const StockDetailPage({super.key, required this.stockCode});
+
+  @override
+  State<StockDetailPage> createState() => _StockDetailPageState();
+}
+
+class _StockDetailPageState extends State<StockDetailPage> {
+  int _selectedTabIndex = 0; // 현재 선택된 하단 탭 인덱스 (0: 개요)
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        // 페이지 제목 없이 뒤로가기 버튼만 있는 깔끔한 AppBar
+      ),
+      body: IndexedStack(
+        index: _selectedTabIndex,
+        children: const [
+          // 0: 개요 탭 (우리가 구현할 내용)
+          Center(child: Text('개요 탭 콘텐츠')),
+          // 1: 일별시세 탭
+          Center(child: Text('일별시세 탭 콘텐츠')),
+          // 2: 재무 탭
+          Center(child: Text('재무 탭 콘텐츠')),
+          // 3: 뉴스/공시 탭
+          Center(child: Text('뉴스/공시 탭 콘텐츠')),
+        ],
+      ),
+      bottomNavigationBar: _buildBottomNavigationBar(),
+    );
+  }
+
+  // 하단 탭 네비게이션 바 위젯
+  Widget _buildBottomNavigationBar() {
+    return BottomNavigationBar(
+      currentIndex: _selectedTabIndex,
+      onTap: (index) {
+        setState(() {
+          _selectedTabIndex = index;
+        });
+      },
+      // 선택 시 라벨과 아이콘 색상
+      selectedItemColor: Colors.black,
+      // 선택 안된 라벨과 아이콘 색상
+      unselectedItemColor: Colors.grey[600],
+      // 선택 시 글자 크기
+      selectedFontSize: 12,
+      // 선택 안된 글자 크기
+      unselectedFontSize: 12,
+      // 아래 탭 아이템들의 타입 설정 (버튼이 4개 이상일 때 필요)
+      type: BottomNavigationBarType.fixed,
+      items: const [
+        BottomNavigationBarItem(icon: Icon(Icons.bar_chart), label: '개요'),
+        BottomNavigationBarItem(icon: Icon(Icons.candlestick_chart), label: '일별시세'),
+        BottomNavigationBarItem(icon: Icon(Icons.assessment), label: '재무'),
+        BottomNavigationBarItem(icon: Icon(Icons.article), label: '뉴스/공시'),
+      ],
+    );
+  }
+}

--- a/lib/features/stock_detail/presentation/stock_detail_page.dart
+++ b/lib/features/stock_detail/presentation/stock_detail_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/overview_tab.dart'; // [추가]
 
 class StockDetailPage extends StatefulWidget {
   final String stockCode; // 라우터로부터 전달받을 종목 코드
@@ -21,13 +22,10 @@ class _StockDetailPageState extends State<StockDetailPage> {
       body: IndexedStack(
         index: _selectedTabIndex,
         children: const [
-          // 0: 개요 탭 (우리가 구현할 내용)
-          Center(child: Text('개요 탭 콘텐츠')),
-          // 1: 일별시세 탭
+          // [핵심 수정] '개요' 탭의 내용을 OverviewTab 위젯으로 교체
+          OverviewTab(),
           Center(child: Text('일별시세 탭 콘텐츠')),
-          // 2: 재무 탭
           Center(child: Text('재무 탭 콘텐츠')),
-          // 3: 뉴스/공시 탭
           Center(child: Text('뉴스/공시 탭 콘텐츠')),
         ],
       ),
@@ -44,15 +42,10 @@ class _StockDetailPageState extends State<StockDetailPage> {
           _selectedTabIndex = index;
         });
       },
-      // 선택 시 라벨과 아이콘 색상
       selectedItemColor: Colors.black,
-      // 선택 안된 라벨과 아이콘 색상
       unselectedItemColor: Colors.grey[600],
-      // 선택 시 글자 크기
       selectedFontSize: 12,
-      // 선택 안된 글자 크기
       unselectedFontSize: 12,
-      // 아래 탭 아이템들의 타입 설정 (버튼이 4개 이상일 때 필요)
       type: BottomNavigationBarType.fixed,
       items: const [
         BottomNavigationBarItem(icon: Icon(Icons.bar_chart), label: '개요'),

--- a/lib/features/stock_detail/presentation/widget/overview_tab.dart
+++ b/lib/features/stock_detail/presentation/widget/overview_tab.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/stock_basic_info_card.dart';
 import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/stock_chart_card.dart';
+import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/stock_company_info_card.dart';
 import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/stock_header.dart';
 
 /// 종목 상세 페이지의 '개요' 탭 UI 전체를 담고 있는 위젯
@@ -23,7 +24,6 @@ class OverviewTab extends StatelessWidget {
     );
 
     final rnd = Random();
-
     final chartData = List.generate(60, (i) {
       final base = 900 + i * 6;
       return ChartDataPoint(
@@ -31,10 +31,8 @@ class OverviewTab extends StatelessWidget {
         volume: 1000000 + rnd.nextDouble() * 5000000,
       );
     });
-
     const xTicks = ['12.24', '1.22', '2.20', '3.20', '4.19'];
 
-    // [핵심 추가] 기본 정보 카드용 임시 데이터
     const basicInfoData = StockBasicInfoData(
       marketCap: '1,234억',
       per: '15.8배',
@@ -43,6 +41,15 @@ class OverviewTab extends StatelessWidget {
       week52High: 1874,
       week52Low: 1060,
       currentPrice: 1275, 
+    );
+
+    // [핵심 추가] 기업 정보 카드용 임시 데이터
+    const companyInfoData = StockCompanyInfoData(
+      sector: 'IT 부품',
+      debtRatio: '85%',
+      netProfitMargin: '9.4%',
+      market: 'KOSDAQ',
+      description: 'IT 부품 사업을 영위하는 기업으로, 최근 매출 신장세를 유지하고 있으며 재무 구조는 비교적 안정적인 편입니다.',
     );
 
     return ListView(
@@ -56,15 +63,11 @@ class OverviewTab extends StatelessWidget {
           periodLabel: '지난 6개월 기준',
         ),
         const SizedBox(height: 24),
-
-        // [핵심 수정] #3 기본 정보 카드 위젯 추가
         StockBasicInfoCard(data: basicInfoData),
         const SizedBox(height: 16),
         
-        const Padding(
-          padding: EdgeInsets.all(8.0),
-          child: Center(child: Text('#4 기업 정보 카드 영역')),
-        ),
+        // [핵심 수정] #4 기업 정보 카드 위젯 추가
+        StockCompanyInfoCard(data: companyInfoData),
       ],
     );
   }

--- a/lib/features/stock_detail/presentation/widget/overview_tab.dart
+++ b/lib/features/stock_detail/presentation/widget/overview_tab.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/stock_chart_card.dart';
 import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/stock_header.dart';
 
 /// 종목 상세 페이지의 '개요' 탭 UI 전체를 담고 있는 위젯
@@ -22,16 +23,13 @@ class OverviewTab extends StatelessWidget {
     return ListView(
       padding: const EdgeInsets.symmetric(vertical: 16.0),
       children: const [
-        // [핵심 수정] #1 주가 헤더 위젯 추가
         StockHeader(data: headerData),
         SizedBox(height: 24),
 
-        // 2. 차트 (만들 예정)
-        Padding(
-          padding: EdgeInsets.all(8.0),
-          child: Center(child: Text('#2 차트 영역')),
-        ),
-        SizedBox(height: 16),
+        // [핵심 수정] #2 차트 위젯 추가
+        StockChartCard(),
+        SizedBox(height: 24),
+        
         // 3. 기본 정보 카드 (만들 예정)
         Padding(
           padding: EdgeInsets.all(8.0),

--- a/lib/features/stock_detail/presentation/widget/overview_tab.dart
+++ b/lib/features/stock_detail/presentation/widget/overview_tab.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/stock_header.dart';
+
+/// 종목 상세 페이지의 '개요' 탭 UI 전체를 담고 있는 위젯
+class OverviewTab extends StatelessWidget {
+  const OverviewTab({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO: 실제 데이터 모델을 외부에서 전달받아야 합니다.
+    const headerData = StockHeaderData(
+      name: '큐로홀딩스',
+      code: '051780',
+      currentPrice: 1275,
+      change: 95,
+      changeRate: 8.05,
+      volume: 2517785,
+      prevClose: 1180,
+      market: 'KOSDAQ',
+    );
+
+    return ListView(
+      padding: const EdgeInsets.symmetric(vertical: 16.0),
+      children: const [
+        // [핵심 수정] #1 주가 헤더 위젯 추가
+        StockHeader(data: headerData),
+        SizedBox(height: 24),
+
+        // 2. 차트 (만들 예정)
+        Padding(
+          padding: EdgeInsets.all(8.0),
+          child: Center(child: Text('#2 차트 영역')),
+        ),
+        SizedBox(height: 16),
+        // 3. 기본 정보 카드 (만들 예정)
+        Padding(
+          padding: EdgeInsets.all(8.0),
+          child: Center(child: Text('#3 기본 정보 카드 영역')),
+        ),
+        SizedBox(height: 16),
+        // 4. 기업 정보 카드 (만들 예정)
+        Padding(
+          padding: EdgeInsets.all(8.0),
+          child: Center(child: Text('#4 기업 정보 카드 영역')),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/stock_detail/presentation/widget/overview_tab.dart
+++ b/lib/features/stock_detail/presentation/widget/overview_tab.dart
@@ -1,3 +1,4 @@
+import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/stock_chart_card.dart';
 import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/stock_header.dart';
@@ -20,24 +21,37 @@ class OverviewTab extends StatelessWidget {
       market: 'KOSDAQ',
     );
 
+    final rnd = Random();
+
+    // 예시: 6개월(약 60영업일) 데이터
+    final chartData = List.generate(60, (i) {
+      final base = 900 + i * 6;
+      return ChartDataPoint(
+        price: base + rnd.nextDouble() * 80 - 40,
+        volume: 1000000 + rnd.nextDouble() * 5000000,
+      );
+    });
+
+    // 예시 X축 라벨(원하면 실제 날짜로 바꿔서 넣으면 됨)
+    const xTicks = ['12.24', '1.22', '2.20', '3.20', '4.19'];
+
     return ListView(
       padding: const EdgeInsets.symmetric(vertical: 16.0),
-      children: const [
+      children: [
         StockHeader(data: headerData),
-        SizedBox(height: 24),
-
-        // [핵심 수정] #2 차트 위젯 추가
-        StockChartCard(),
-        SizedBox(height: 24),
-        
-        // 3. 기본 정보 카드 (만들 예정)
-        Padding(
+        const SizedBox(height: 16),
+        StockChartCard(
+          chartData: chartData,
+          xTicks: xTicks,
+          periodLabel: '지난 6개월 기준',
+        ),
+        const SizedBox(height: 24),
+        const Padding(
           padding: EdgeInsets.all(8.0),
           child: Center(child: Text('#3 기본 정보 카드 영역')),
         ),
-        SizedBox(height: 16),
-        // 4. 기업 정보 카드 (만들 예정)
-        Padding(
+        const SizedBox(height: 16),
+        const Padding(
           padding: EdgeInsets.all(8.0),
           child: Center(child: Text('#4 기업 정보 카드 영역')),
         ),

--- a/lib/features/stock_detail/presentation/widget/overview_tab.dart
+++ b/lib/features/stock_detail/presentation/widget/overview_tab.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 import 'package:flutter/material.dart';
+import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/stock_basic_info_card.dart';
 import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/stock_chart_card.dart';
 import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/stock_header.dart';
 
@@ -23,7 +24,6 @@ class OverviewTab extends StatelessWidget {
 
     final rnd = Random();
 
-    // 예시: 6개월(약 60영업일) 데이터
     final chartData = List.generate(60, (i) {
       final base = 900 + i * 6;
       return ChartDataPoint(
@@ -32,8 +32,18 @@ class OverviewTab extends StatelessWidget {
       );
     });
 
-    // 예시 X축 라벨(원하면 실제 날짜로 바꿔서 넣으면 됨)
     const xTicks = ['12.24', '1.22', '2.20', '3.20', '4.19'];
+
+    // [핵심 추가] 기본 정보 카드용 임시 데이터
+    const basicInfoData = StockBasicInfoData(
+      marketCap: '1,234억',
+      per: '15.8배',
+      roe: '9.7%',
+      dividendYield: '-',
+      week52High: 1874,
+      week52Low: 1060,
+      currentPrice: 1275, 
+    );
 
     return ListView(
       padding: const EdgeInsets.symmetric(vertical: 16.0),
@@ -46,11 +56,11 @@ class OverviewTab extends StatelessWidget {
           periodLabel: '지난 6개월 기준',
         ),
         const SizedBox(height: 24),
-        const Padding(
-          padding: EdgeInsets.all(8.0),
-          child: Center(child: Text('#3 기본 정보 카드 영역')),
-        ),
+
+        // [핵심 수정] #3 기본 정보 카드 위젯 추가
+        StockBasicInfoCard(data: basicInfoData),
         const SizedBox(height: 16),
+        
         const Padding(
           padding: EdgeInsets.all(8.0),
           child: Center(child: Text('#4 기업 정보 카드 영역')),

--- a/lib/features/stock_detail/presentation/widget/stock_basic_info_card.dart
+++ b/lib/features/stock_detail/presentation/widget/stock_basic_info_card.dart
@@ -35,7 +35,8 @@ class StockBasicInfoCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: Colors.grey[200]!),
+        // [핵심 수정] 테두리 색상을 더 진하게 변경
+        border: Border.all(color: const Color(0xFFE0E0E0)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -87,7 +88,6 @@ class StockBasicInfoCard extends StatelessWidget {
 
   // 52주 최저/최고 바 위젯
   Widget _build52WeekRange() {
-    // 현재 가격이 52주 범위를 벗어날 경우를 대비해, 값을 0.0과 1.0 사이로 제한합니다.
     final double currentPosition = ((data.currentPrice - data.week52Low) / (data.week52High - data.week52Low)).clamp(0.0, 1.0);
 
     return Column(

--- a/lib/features/stock_detail/presentation/widget/stock_basic_info_card.dart
+++ b/lib/features/stock_detail/presentation/widget/stock_basic_info_card.dart
@@ -35,7 +35,6 @@ class StockBasicInfoCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(16),
-        // [핵심 수정] 테두리 색상을 더 진하게 변경
         border: Border.all(color: const Color(0xFFE0E0E0)),
       ),
       child: Column(
@@ -88,7 +87,11 @@ class StockBasicInfoCard extends StatelessWidget {
 
   // 52주 최저/최고 바 위젯
   Widget _build52WeekRange() {
-    final double currentPosition = ((data.currentPrice - data.week52Low) / (data.week52High - data.week52Low)).clamp(0.0, 1.0);
+    // 0으로 나누기 오류 방지
+    final range = data.week52High - data.week52Low;
+    final double currentPosition = range == 0
+        ? 0.5
+        : ((data.currentPrice - data.week52Low) / range).clamp(0.0, 1.0);
 
     return Column(
       children: [

--- a/lib/features/stock_detail/presentation/widget/stock_basic_info_card.dart
+++ b/lib/features/stock_detail/presentation/widget/stock_basic_info_card.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+
+// 위젯에 전달될 데이터 모델
+class StockBasicInfoData {
+  final String marketCap;
+  final String per;
+  final String roe;
+  final String dividendYield;
+  final int week52High;
+  final int week52Low;
+  final int currentPrice;
+
+  const StockBasicInfoData({
+    required this.marketCap,
+    required this.per,
+    required this.roe,
+    required this.dividendYield,
+    required this.week52High,
+    required this.week52Low,
+    required this.currentPrice,
+  });
+}
+
+/// 종목 상세 - 개요 탭의 '기본 정보' 카드 위젯
+class StockBasicInfoCard extends StatelessWidget {
+  final StockBasicInfoData data;
+
+  const StockBasicInfoCard({super.key, required this.data});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 20),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: Colors.grey[200]!),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('기본 정보', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 16),
+          // 2x2 그리드
+          Table(
+            children: [
+              TableRow(
+                children: [
+                  _buildInfoItem('시가총액', data.marketCap),
+                  _buildInfoItem('ROE', data.roe),
+                ],
+              ),
+              TableRow(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(top: 16.0),
+                    child: _buildInfoItem('주가수익비율(PER)', data.per),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 16.0),
+                    child: _buildInfoItem('배당수익률', data.dividendYield),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          const SizedBox(height: 20),
+          // 52주 최저/최고
+          _build52WeekRange(),
+        ],
+      ),
+    );
+  }
+
+  // 그리드 아이템 위젯
+  Widget _buildInfoItem(String title, String value) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: TextStyle(fontSize: 13, color: Colors.grey[600])),
+        const SizedBox(height: 4),
+        Text(value, style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500)),
+      ],
+    );
+  }
+
+  // 52주 최저/최고 바 위젯
+  Widget _build52WeekRange() {
+    // 현재 가격이 52주 범위를 벗어날 경우를 대비해, 값을 0.0과 1.0 사이로 제한합니다.
+    final double currentPosition = ((data.currentPrice - data.week52Low) / (data.week52High - data.week52Low)).clamp(0.0, 1.0);
+
+    return Column(
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text('52주 최저', style: TextStyle(color: Colors.blue[600], fontSize: 12)),
+            Text('52주 최고', style: TextStyle(color: Colors.red[600], fontSize: 12)),
+          ],
+        ),
+        const SizedBox(height: 4),
+        SizedBox(
+          height: 10,
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(5),
+            child: LinearProgressIndicator(
+              value: currentPosition,
+              backgroundColor: Colors.grey[200],
+              valueColor: const AlwaysStoppedAnimation<Color>(Colors.blue),
+            ),
+          ),
+        ),
+        const SizedBox(height: 4),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text('${data.week52Low}', style: const TextStyle(fontSize: 12, fontWeight: FontWeight.bold)),
+            Text('${data.week52High}', style: const TextStyle(fontSize: 12, fontWeight: FontWeight.bold)),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/stock_detail/presentation/widget/stock_chart_card.dart
+++ b/lib/features/stock_detail/presentation/widget/stock_chart_card.dart
@@ -1,35 +1,478 @@
+import 'dart:math';
 import 'package:flutter/material.dart';
 
-/// 종목 상세 - 개요 탭의 차트 카드 위젯 (단순화 버전)
+class ChartDataPoint {
+  final double price;
+  final double volume;
+
+  ChartDataPoint({required this.price, required this.volume});
+}
+
 class StockChartCard extends StatelessWidget {
-  const StockChartCard({super.key});
+  final List<ChartDataPoint> chartData;
+  final List<String>? xTicks; // optional: 하단 날짜 라벨
+  final String periodLabel;
+
+  ///오른쪽 축 레이블(1292/877/5.9M) 표시 여부
+  final bool showRightAxisLabels;
+
+  ///하단 요약 (최고/최저/최대거래량) 표시 여부
+  final bool showSummaryLegend;
+
+
+
+  const StockChartCard({
+    super.key,
+    required this.chartData,
+    this.xTicks,
+    this.periodLabel = '지난 6개월 기준',
+    this.showRightAxisLabels = true,
+    this.showSummaryLegend = false,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.end, // 텍스트를 오른쪽으로 정렬
-      children: [
-        // 1. 주가 차트 + 거래량 차트 영역
-        Container(
-          height: 250, // 임시 높이
-          margin: const EdgeInsets.symmetric(horizontal: 20),
-          decoration: BoxDecoration(
-            color: Colors.grey[200],
-            borderRadius: BorderRadius.circular(8), // 약간의 둥근 모서리 추가
-          ),
-          child: const Center(child: Text('주가 & 거래량 차트')),
-        ),
-        const SizedBox(height: 8),
+    final theme = Theme.of(context);
 
-        // 2. 기준 기간 텍스트
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 20.0),
-          child: Text(
-            '지난 6개월 기준',
-            style: TextStyle(color: Colors.grey[600], fontSize: 12),
+    // 요약값 계산 (데이터 없으면 스킵)
+    final summary = chartData.isEmpty
+        ? null
+        : _ChartSummary(
+      maxPrice: chartData.map((e) => e.price).reduce(max),
+      minPrice: chartData.map((e) => e.price).reduce(min),
+      maxVolume: chartData.map((e) => e.volume).reduce(max),
+    );
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: theme.cardColor,
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(color: theme.dividerColor.withOpacity(0.15)),
+          boxShadow: [
+            BoxShadow(
+              blurRadius: 18,
+              offset: const Offset(0, 8),
+              color: Colors.black.withOpacity(0.06),
+            ),
+          ],
+        ),
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(12, 12, 12, 10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              RepaintBoundary(
+                child: SizedBox(
+                  height: 250,
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(12),
+                    child: CustomPaint(
+                      painter: _StockChartPainter(
+                        data: chartData,
+                        theme: theme,
+                        xTicks: xTicks,
+                        showRightAxisLabels: showRightAxisLabels,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+
+              // 하단 요약(칩)
+              if (showSummaryLegend && summary != null) ...[
+                const SizedBox(height: 10),
+                _SummaryLegend(summary: summary),
+              ],
+
+              const SizedBox(height: 8),
+              Align(
+                alignment: Alignment.centerRight,
+                child: Text(
+                  periodLabel,
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: theme.hintColor.withOpacity(0.9),
+                  ),
+                ),
+              ),
+            ],
           ),
         ),
+      ),
+    );
+  }
+}
+
+class _ChartSummary {
+  final double maxPrice;
+  final double minPrice;
+  final double maxVolume;
+
+  const _ChartSummary({
+    required this.maxPrice,
+    required this.minPrice,
+    required this.maxVolume,
+  });
+}
+
+class _SummaryLegend extends StatelessWidget {
+  final _ChartSummary summary;
+  const _SummaryLegend({required this.summary});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    Widget chip(String label, String value) {
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surface.withOpacity(0.6),
+          borderRadius: BorderRadius.circular(999),
+          border: Border.all(color: theme.dividerColor.withOpacity(0.15)),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              label,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.hintColor.withOpacity(0.95),
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(width: 6),
+            Text(
+              value,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: theme.colorScheme.onSurface.withOpacity(0.85),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final maxPriceText = _formatIntWithComma(summary.maxPrice.round());
+    final minPriceText = _formatIntWithComma(summary.minPrice.round());
+    final maxVolText = _formatVolume(summary.maxVolume);
+
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      alignment: WrapAlignment.start,
+      children: [
+        chip('최고가', maxPriceText),
+        chip('최저가', minPriceText),
+        chip('최대 거래량', maxVolText),
       ],
     );
+  }
+
+  String _formatIntWithComma(int n) {
+    final s = n.toString();
+    final buf = StringBuffer();
+    for (int i = 0; i < s.length; i++) {
+      final posFromEnd = s.length - i;
+      buf.write(s[i]);
+      if (posFromEnd > 1 && posFromEnd % 3 == 1) buf.write(',');
+    }
+    return buf.toString();
+  }
+
+  String _formatVolume(double v) {
+    if (v >= 1000000) return '${(v / 1000000).toStringAsFixed(1)}M';
+    if (v >= 1000) return '${(v / 1000).toStringAsFixed(1)}K';
+    return v.toStringAsFixed(0);
+  }
+}
+
+class _StockChartPainter extends CustomPainter {
+  final List<ChartDataPoint> data;
+  final ThemeData theme;
+  final List<String>? xTicks;
+
+  /// ✅ 추가
+  final bool showRightAxisLabels;
+
+  _StockChartPainter({
+    required this.data,
+    required this.theme,
+    required this.xTicks,
+    required this.showRightAxisLabels,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (data.length < 2) return;
+
+    // ===== 레이아웃(패딩/영역) =====
+    // 레퍼런스처럼 "오른쪽 레이블" 공간을 확보
+    const padLeft = 10.0;
+    const padTop = 12.0;
+    const padBottom = 22.0;
+    const padRight = 46.0;
+
+    final fullRect = Offset.zero & size;
+    final plotRect = Rect.fromLTWH(
+      padLeft,
+      padTop,
+      size.width - padLeft - padRight,
+      size.height - padTop - padBottom,
+    );
+
+    // 가격(상단) / 거래량(하단) 비율
+    final priceRect = Rect.fromLTWH(
+      plotRect.left,
+      plotRect.top,
+      plotRect.width,
+      plotRect.height * 0.72,
+    );
+    final volumeRect = Rect.fromLTWH(
+      plotRect.left,
+      priceRect.bottom + plotRect.height * 0.04,
+      plotRect.width,
+      plotRect.height * 0.24,
+    );
+
+    // ===== 데이터 스케일 =====
+    final prices = data.map((e) => e.price).toList();
+    final volumes = data.map((e) => e.volume).toList();
+
+    double maxPrice = prices.reduce(max);
+    double minPrice = prices.reduce(min);
+    final maxVolume = volumes.reduce(max);
+
+    // min==max 방어
+    if ((maxPrice - minPrice).abs() < 1e-9) {
+      maxPrice += 1;
+      minPrice -= 1;
+    }
+
+    // 약간의 여유(상하 마진) 추가
+    final priceRange = maxPrice - minPrice;
+    maxPrice += priceRange * 0.06;
+    minPrice -= priceRange * 0.06;
+
+    // ===== 스타일 =====
+    final gridPaint = Paint()
+      ..color = theme.dividerColor.withOpacity(0.10)
+      ..strokeWidth = 1;
+
+    final linePaint = Paint()
+      ..color = theme.colorScheme.onSurface.withOpacity(0.55) // 회색 라인 느낌
+      ..strokeWidth = 2.0
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round
+      ..isAntiAlias = true;
+
+    final barPaint = Paint()
+      ..color = Colors.blueAccent.withOpacity(0.55)
+      ..style = PaintingStyle.fill
+      ..isAntiAlias = true;
+
+    final labelStyle = theme.textTheme.labelSmall?.copyWith(
+      color: theme.hintColor.withOpacity(0.9),
+      fontSize: 11,
+    );
+
+    // ===== 배경(살짝 밝게) =====
+    canvas.drawRect(
+      fullRect,
+      Paint()..color = theme.scaffoldBackgroundColor.withOpacity(0.02),
+    );
+
+    // ===== 그리드(가격 영역 가로선) =====
+    const gridLines = 4;
+    for (int i = 0; i <= gridLines; i++) {
+      final y = priceRect.top + (priceRect.height / gridLines) * i;
+      canvas.drawLine(Offset(priceRect.left, y), Offset(priceRect.right, y), gridPaint);
+    }
+
+    // ===== 포인트 -> 좌표 변환 =====
+    final stepX = priceRect.width / (data.length - 1);
+
+    double priceToY(double p) {
+      final t = (p - minPrice) / (maxPrice - minPrice);
+      return priceRect.bottom - t * priceRect.height;
+    }
+
+    double volumeToH(double v) {
+      if (maxVolume <= 0) return 0;
+      final t = (v / maxVolume).clamp(0.0, 1.0);
+      return t * volumeRect.height;
+    }
+
+    final points = <Offset>[];
+    for (int i = 0; i < data.length; i++) {
+      final x = priceRect.left + stepX * i;
+      final y = priceToY(data[i].price);
+      points.add(Offset(x, y));
+    }
+
+    // ===== 거래량 막대 =====
+    final barW = (stepX * 0.55).clamp(2.5, 7.0);
+    for (int i = 0; i < data.length; i++) {
+      final x = volumeRect.left + stepX * i;
+      final h = volumeToH(data[i].volume);
+      final r = Rect.fromLTWH(
+        x - barW / 2,
+        volumeRect.bottom - h,
+        barW,
+        h,
+      );
+
+      // 라운드 처리(레퍼런스처럼 부드럽게)
+      final rr = RRect.fromRectAndRadius(r, const Radius.circular(2.5));
+      canvas.drawRRect(rr, barPaint);
+    }
+
+    // 거래량 바닥선
+    canvas.drawLine(
+      Offset(volumeRect.left, volumeRect.bottom),
+      Offset(volumeRect.right, volumeRect.bottom),
+      gridPaint,
+    );
+
+    // ===== 가격 라인: 부드럽게(스무딩 path) =====
+    final smoothPath = _catmullRomToBezier(points);
+
+    // ===== 라인 아래 그라데이션 채움(레퍼런스 핵심 포인트) =====
+    final fillPath = Path.from(smoothPath)
+      ..lineTo(points.last.dx, priceRect.bottom)
+      ..lineTo(points.first.dx, priceRect.bottom)
+      ..close();
+
+    final fillPaint = Paint()
+      ..shader = LinearGradient(
+        begin: Alignment.topCenter,
+        end: Alignment.bottomCenter,
+        colors: [
+          theme.colorScheme.onSurface.withOpacity(0.10),
+          theme.colorScheme.onSurface.withOpacity(0.00),
+        ],
+      ).createShader(priceRect);
+
+    canvas.drawPath(fillPath, fillPaint);
+
+    // 가격 라인 그리기
+    canvas.drawPath(smoothPath, linePaint);
+
+    // ===== 오른쪽 레이블(최대/최소, 거래량 Max) =====
+    if (showRightAxisLabels) {
+      _drawRightLabel(
+        canvas,
+        text: _formatNumber(maxPrice),
+        x: plotRect.right + 6,
+        y: priceRect.top - 2,
+        style: labelStyle,
+      );
+
+      _drawRightLabel(
+        canvas,
+        text: _formatNumber(minPrice),
+        x: plotRect.right + 6,
+        y: priceRect.bottom - 12,
+        style: labelStyle,
+      );
+
+      _drawRightLabel(
+        canvas,
+        text: _formatVolume(maxVolume),
+        x: plotRect.right + 6,
+        y: volumeRect.top - 2,
+        style: labelStyle,
+      );
+    }
+
+    // ===== 하단 X 라벨(옵션) =====
+    if (xTicks != null && xTicks!.isNotEmpty) {
+      _drawXTicks(canvas, plotRect, xTicks!, labelStyle);
+    }
+  }
+
+  // Catmull-Rom spline -> cubic Bezier path
+  Path _catmullRomToBezier(List<Offset> pts, {double tension = 0.2}) {
+    final p = pts;
+    final path = Path()..moveTo(p[0].dx, p[0].dy);
+
+    for (int i = 0; i < p.length - 1; i++) {
+      final p0 = i == 0 ? p[i] : p[i - 1];
+      final p1 = p[i];
+      final p2 = p[i + 1];
+      final p3 = (i + 2 < p.length) ? p[i + 2] : p2;
+
+      final c1 = Offset(
+        p1.dx + (p2.dx - p0.dx) * tension,
+        p1.dy + (p2.dy - p0.dy) * tension,
+      );
+      final c2 = Offset(
+        p2.dx - (p3.dx - p1.dx) * tension,
+        p2.dy - (p3.dy - p1.dy) * tension,
+      );
+
+      path.cubicTo(c1.dx, c1.dy, c2.dx, c2.dy, p2.dx, p2.dy);
+    }
+    return path;
+  }
+
+  void _drawRightLabel(
+      Canvas canvas, {
+        required String text,
+        required double x,
+        required double y,
+        required TextStyle? style,
+      }) {
+    final tp = TextPainter(
+      text: TextSpan(text: text, style: style),
+      textDirection: TextDirection.ltr,
+    )..layout();
+
+    tp.paint(canvas, Offset(x, y));
+  }
+
+  void _drawXTicks(Canvas canvas, Rect plotRect, List<String> ticks, TextStyle? style) {
+    // ticks를 균등하게 배치
+    final count = ticks.length;
+    if (count < 2) return;
+
+    final tpList = ticks
+        .map((t) => TextPainter(
+      text: TextSpan(text: t, style: style),
+      textDirection: TextDirection.ltr,
+    )..layout())
+        .toList();
+
+    for (int i = 0; i < count; i++) {
+      final t = i / (count - 1);
+      final x = plotRect.left + plotRect.width * t;
+      final tp = tpList[i];
+
+      // 좌/우 끝은 살짝 안으로
+      double dx = x - tp.width / 2;
+      dx = dx.clamp(plotRect.left, plotRect.right - tp.width);
+
+      tp.paint(canvas, Offset(dx, plotRect.bottom + 4));
+    }
+  }
+
+  String _formatNumber(double v) {
+    // 레퍼런스처럼 정수에 가깝게
+    final n = v.round();
+    return n.toString();
+  }
+
+  String _formatVolume(double v) {
+    // 6.0M 형태
+    if (v >= 1000000) return '${(v / 1000000).toStringAsFixed(1)}M';
+    if (v >= 1000) return '${(v / 1000).toStringAsFixed(1)}K';
+    return v.toStringAsFixed(0);
+  }
+
+  @override
+  bool shouldRepaint(covariant _StockChartPainter oldDelegate) {
+    return oldDelegate.data != data || oldDelegate.theme != theme || oldDelegate.xTicks != xTicks;
   }
 }

--- a/lib/features/stock_detail/presentation/widget/stock_chart_card.dart
+++ b/lib/features/stock_detail/presentation/widget/stock_chart_card.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+/// 종목 상세 - 개요 탭의 차트 카드 위젯 (단순화 버전)
+class StockChartCard extends StatelessWidget {
+  const StockChartCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.end, // 텍스트를 오른쪽으로 정렬
+      children: [
+        // 1. 주가 차트 + 거래량 차트 영역
+        Container(
+          height: 250, // 임시 높이
+          margin: const EdgeInsets.symmetric(horizontal: 20),
+          decoration: BoxDecoration(
+            color: Colors.grey[200],
+            borderRadius: BorderRadius.circular(8), // 약간의 둥근 모서리 추가
+          ),
+          child: const Center(child: Text('주가 & 거래량 차트')),
+        ),
+        const SizedBox(height: 8),
+
+        // 2. 기준 기간 텍스트
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20.0),
+          child: Text(
+            '지난 6개월 기준',
+            style: TextStyle(color: Colors.grey[600], fontSize: 12),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/stock_detail/presentation/widget/stock_chart_card.dart
+++ b/lib/features/stock_detail/presentation/widget/stock_chart_card.dart
@@ -10,16 +10,10 @@ class ChartDataPoint {
 
 class StockChartCard extends StatelessWidget {
   final List<ChartDataPoint> chartData;
-  final List<String>? xTicks; // optional: 하단 날짜 라벨
+  final List<String>? xTicks;
   final String periodLabel;
-
-  ///오른쪽 축 레이블(1292/877/5.9M) 표시 여부
   final bool showRightAxisLabels;
-
-  ///하단 요약 (최고/최저/최대거래량) 표시 여부
   final bool showSummaryLegend;
-
-
 
   const StockChartCard({
     super.key,
@@ -34,14 +28,13 @@ class StockChartCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    // 요약값 계산 (데이터 없으면 스킵)
     final summary = chartData.isEmpty
         ? null
         : _ChartSummary(
-      maxPrice: chartData.map((e) => e.price).reduce(max),
-      minPrice: chartData.map((e) => e.price).reduce(min),
-      maxVolume: chartData.map((e) => e.volume).reduce(max),
-    );
+            maxPrice: chartData.map((e) => e.price).reduce(max),
+            minPrice: chartData.map((e) => e.price).reduce(min),
+            maxVolume: chartData.map((e) => e.volume).reduce(max),
+          );
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 20),
@@ -49,12 +42,12 @@ class StockChartCard extends StatelessWidget {
         decoration: BoxDecoration(
           color: theme.cardColor,
           borderRadius: BorderRadius.circular(16),
-          border: Border.all(color: theme.dividerColor.withOpacity(0.15)),
+          border: Border.all(color: theme.dividerColor.withAlpha((0.15 * 255).round())),
           boxShadow: [
             BoxShadow(
               blurRadius: 18,
               offset: const Offset(0, 8),
-              color: Colors.black.withOpacity(0.06),
+              color: Colors.black.withAlpha((0.06 * 255).round()),
             ),
           ],
         ),
@@ -79,20 +72,17 @@ class StockChartCard extends StatelessWidget {
                   ),
                 ),
               ),
-
-              // 하단 요약(칩)
               if (showSummaryLegend && summary != null) ...[
                 const SizedBox(height: 10),
                 _SummaryLegend(summary: summary),
               ],
-
               const SizedBox(height: 8),
               Align(
                 alignment: Alignment.centerRight,
                 child: Text(
                   periodLabel,
                   style: theme.textTheme.labelSmall?.copyWith(
-                    color: theme.hintColor.withOpacity(0.9),
+                    color: theme.hintColor.withAlpha((0.9 * 255).round()),
                   ),
                 ),
               ),
@@ -128,9 +118,9 @@ class _SummaryLegend extends StatelessWidget {
       return Container(
         padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
         decoration: BoxDecoration(
-          color: theme.colorScheme.surface.withOpacity(0.6),
+          color: theme.colorScheme.surface.withAlpha((0.6 * 255).round()),
           borderRadius: BorderRadius.circular(999),
-          border: Border.all(color: theme.dividerColor.withOpacity(0.15)),
+          border: Border.all(color: theme.dividerColor.withAlpha((0.15 * 255).round())),
         ),
         child: Row(
           mainAxisSize: MainAxisSize.min,
@@ -138,7 +128,7 @@ class _SummaryLegend extends StatelessWidget {
             Text(
               label,
               style: theme.textTheme.labelSmall?.copyWith(
-                color: theme.hintColor.withOpacity(0.95),
+                color: theme.hintColor.withAlpha((0.95 * 255).round()),
                 fontWeight: FontWeight.w600,
               ),
             ),
@@ -146,7 +136,7 @@ class _SummaryLegend extends StatelessWidget {
             Text(
               value,
               style: theme.textTheme.labelSmall?.copyWith(
-                color: theme.colorScheme.onSurface.withOpacity(0.85),
+                color: theme.colorScheme.onSurface.withAlpha((0.85 * 255).round()),
               ),
             ),
           ],
@@ -192,8 +182,6 @@ class _StockChartPainter extends CustomPainter {
   final List<ChartDataPoint> data;
   final ThemeData theme;
   final List<String>? xTicks;
-
-  /// ✅ 추가
   final bool showRightAxisLabels;
 
   _StockChartPainter({
@@ -207,8 +195,6 @@ class _StockChartPainter extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     if (data.length < 2) return;
 
-    // ===== 레이아웃(패딩/영역) =====
-    // 레퍼런스처럼 "오른쪽 레이블" 공간을 확보
     const padLeft = 10.0;
     const padTop = 12.0;
     const padBottom = 22.0;
@@ -222,7 +208,6 @@ class _StockChartPainter extends CustomPainter {
       size.height - padTop - padBottom,
     );
 
-    // 가격(상단) / 거래량(하단) 비율
     final priceRect = Rect.fromLTWH(
       plotRect.left,
       plotRect.top,
@@ -236,7 +221,6 @@ class _StockChartPainter extends CustomPainter {
       plotRect.height * 0.24,
     );
 
-    // ===== 데이터 스케일 =====
     final prices = data.map((e) => e.price).toList();
     final volumes = data.map((e) => e.volume).toList();
 
@@ -244,24 +228,21 @@ class _StockChartPainter extends CustomPainter {
     double minPrice = prices.reduce(min);
     final maxVolume = volumes.reduce(max);
 
-    // min==max 방어
     if ((maxPrice - minPrice).abs() < 1e-9) {
       maxPrice += 1;
       minPrice -= 1;
     }
 
-    // 약간의 여유(상하 마진) 추가
     final priceRange = maxPrice - minPrice;
     maxPrice += priceRange * 0.06;
     minPrice -= priceRange * 0.06;
 
-    // ===== 스타일 =====
     final gridPaint = Paint()
-      ..color = theme.dividerColor.withOpacity(0.10)
+      ..color = theme.dividerColor.withAlpha((0.10 * 255).round())
       ..strokeWidth = 1;
 
     final linePaint = Paint()
-      ..color = theme.colorScheme.onSurface.withOpacity(0.55) // 회색 라인 느낌
+      ..color = theme.colorScheme.onSurface.withAlpha((0.55 * 255).round())
       ..strokeWidth = 2.0
       ..style = PaintingStyle.stroke
       ..strokeCap = StrokeCap.round
@@ -269,29 +250,26 @@ class _StockChartPainter extends CustomPainter {
       ..isAntiAlias = true;
 
     final barPaint = Paint()
-      ..color = Colors.blueAccent.withOpacity(0.55)
+      ..color = Colors.blueAccent.withAlpha((0.55 * 255).round())
       ..style = PaintingStyle.fill
       ..isAntiAlias = true;
 
     final labelStyle = theme.textTheme.labelSmall?.copyWith(
-      color: theme.hintColor.withOpacity(0.9),
+      color: theme.hintColor.withAlpha((0.9 * 255).round()),
       fontSize: 11,
     );
 
-    // ===== 배경(살짝 밝게) =====
     canvas.drawRect(
       fullRect,
-      Paint()..color = theme.scaffoldBackgroundColor.withOpacity(0.02),
+      Paint()..color = theme.scaffoldBackgroundColor.withAlpha((0.02 * 255).round()),
     );
 
-    // ===== 그리드(가격 영역 가로선) =====
     const gridLines = 4;
     for (int i = 0; i <= gridLines; i++) {
       final y = priceRect.top + (priceRect.height / gridLines) * i;
       canvas.drawLine(Offset(priceRect.left, y), Offset(priceRect.right, y), gridPaint);
     }
 
-    // ===== 포인트 -> 좌표 변환 =====
     final stepX = priceRect.width / (data.length - 1);
 
     double priceToY(double p) {
@@ -312,7 +290,6 @@ class _StockChartPainter extends CustomPainter {
       points.add(Offset(x, y));
     }
 
-    // ===== 거래량 막대 =====
     final barW = (stepX * 0.55).clamp(2.5, 7.0);
     for (int i = 0; i < data.length; i++) {
       final x = volumeRect.left + stepX * i;
@@ -323,23 +300,18 @@ class _StockChartPainter extends CustomPainter {
         barW,
         h,
       );
-
-      // 라운드 처리(레퍼런스처럼 부드럽게)
       final rr = RRect.fromRectAndRadius(r, const Radius.circular(2.5));
       canvas.drawRRect(rr, barPaint);
     }
 
-    // 거래량 바닥선
     canvas.drawLine(
       Offset(volumeRect.left, volumeRect.bottom),
       Offset(volumeRect.right, volumeRect.bottom),
       gridPaint,
     );
 
-    // ===== 가격 라인: 부드럽게(스무딩 path) =====
     final smoothPath = _catmullRomToBezier(points);
 
-    // ===== 라인 아래 그라데이션 채움(레퍼런스 핵심 포인트) =====
     final fillPath = Path.from(smoothPath)
       ..lineTo(points.last.dx, priceRect.bottom)
       ..lineTo(points.first.dx, priceRect.bottom)
@@ -350,17 +322,15 @@ class _StockChartPainter extends CustomPainter {
         begin: Alignment.topCenter,
         end: Alignment.bottomCenter,
         colors: [
-          theme.colorScheme.onSurface.withOpacity(0.10),
-          theme.colorScheme.onSurface.withOpacity(0.00),
+          theme.colorScheme.onSurface.withAlpha((0.10 * 255).round()),
+          theme.colorScheme.onSurface.withAlpha(0),
         ],
       ).createShader(priceRect);
 
     canvas.drawPath(fillPath, fillPaint);
 
-    // 가격 라인 그리기
     canvas.drawPath(smoothPath, linePaint);
 
-    // ===== 오른쪽 레이블(최대/최소, 거래량 Max) =====
     if (showRightAxisLabels) {
       _drawRightLabel(
         canvas,
@@ -369,7 +339,6 @@ class _StockChartPainter extends CustomPainter {
         y: priceRect.top - 2,
         style: labelStyle,
       );
-
       _drawRightLabel(
         canvas,
         text: _formatNumber(minPrice),
@@ -377,7 +346,6 @@ class _StockChartPainter extends CustomPainter {
         y: priceRect.bottom - 12,
         style: labelStyle,
       );
-
       _drawRightLabel(
         canvas,
         text: _formatVolume(maxVolume),
@@ -387,13 +355,11 @@ class _StockChartPainter extends CustomPainter {
       );
     }
 
-    // ===== 하단 X 라벨(옵션) =====
     if (xTicks != null && xTicks!.isNotEmpty) {
       _drawXTicks(canvas, plotRect, xTicks!, labelStyle);
     }
   }
 
-  // Catmull-Rom spline -> cubic Bezier path
   Path _catmullRomToBezier(List<Offset> pts, {double tension = 0.2}) {
     final p = pts;
     final path = Path()..moveTo(p[0].dx, p[0].dy);
@@ -434,15 +400,14 @@ class _StockChartPainter extends CustomPainter {
   }
 
   void _drawXTicks(Canvas canvas, Rect plotRect, List<String> ticks, TextStyle? style) {
-    // ticks를 균등하게 배치
     final count = ticks.length;
     if (count < 2) return;
 
     final tpList = ticks
         .map((t) => TextPainter(
-      text: TextSpan(text: t, style: style),
-      textDirection: TextDirection.ltr,
-    )..layout())
+              text: TextSpan(text: t, style: style),
+              textDirection: TextDirection.ltr,
+            )..layout())
         .toList();
 
     for (int i = 0; i < count; i++) {
@@ -450,7 +415,6 @@ class _StockChartPainter extends CustomPainter {
       final x = plotRect.left + plotRect.width * t;
       final tp = tpList[i];
 
-      // 좌/우 끝은 살짝 안으로
       double dx = x - tp.width / 2;
       dx = dx.clamp(plotRect.left, plotRect.right - tp.width);
 
@@ -459,13 +423,11 @@ class _StockChartPainter extends CustomPainter {
   }
 
   String _formatNumber(double v) {
-    // 레퍼런스처럼 정수에 가깝게
     final n = v.round();
     return n.toString();
   }
 
   String _formatVolume(double v) {
-    // 6.0M 형태
     if (v >= 1000000) return '${(v / 1000000).toStringAsFixed(1)}M';
     if (v >= 1000) return '${(v / 1000).toStringAsFixed(1)}K';
     return v.toStringAsFixed(0);
@@ -473,6 +435,8 @@ class _StockChartPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant _StockChartPainter oldDelegate) {
-    return oldDelegate.data != data || oldDelegate.theme != theme || oldDelegate.xTicks != xTicks;
+    return oldDelegate.data != data ||
+        oldDelegate.theme != theme ||
+        oldDelegate.xTicks != xTicks;
   }
 }

--- a/lib/features/stock_detail/presentation/widget/stock_company_info_card.dart
+++ b/lib/features/stock_detail/presentation/widget/stock_company_info_card.dart
@@ -31,7 +31,8 @@ class StockCompanyInfoCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: Colors.grey[200]!),
+        // [핵심 수정] 테두리 색상을 더 진하게 변경
+        border: Border.all(color: const Color(0xFFE0E0E0)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/stock_detail/presentation/widget/stock_company_info_card.dart
+++ b/lib/features/stock_detail/presentation/widget/stock_company_info_card.dart
@@ -31,7 +31,6 @@ class StockCompanyInfoCard extends StatelessWidget {
       decoration: BoxDecoration(
         color: Colors.white,
         borderRadius: BorderRadius.circular(16),
-        // [핵심 수정] 테두리 색상을 더 진하게 변경
         border: Border.all(color: const Color(0xFFE0E0E0)),
       ),
       child: Column(
@@ -39,7 +38,6 @@ class StockCompanyInfoCard extends StatelessWidget {
         children: [
           const Text('기업 정보', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
           const SizedBox(height: 16),
-          // 2x2 그리드
           Table(
             children: [
               TableRow(
@@ -66,7 +64,12 @@ class StockCompanyInfoCard extends StatelessWidget {
             padding: EdgeInsets.symmetric(vertical: 16.0),
             child: Divider(),
           ),
-          // 기업 소개
+          // [핵심 추가] '기업 소개' 소제목 추가
+          Text(
+            '기업 소개',
+            style: TextStyle(fontSize: 13, color: Colors.grey[600]),
+          ),
+          const SizedBox(height: 8),
           Text(
             data.description,
             style: TextStyle(fontSize: 14, color: Colors.grey[800], height: 1.5),
@@ -76,7 +79,6 @@ class StockCompanyInfoCard extends StatelessWidget {
     );
   }
 
-  // 그리드 아이템 위젯
   Widget _buildInfoItem(String title, String value) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/stock_detail/presentation/widget/stock_company_info_card.dart
+++ b/lib/features/stock_detail/presentation/widget/stock_company_info_card.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+
+// 위젯에 전달될 데이터 모델
+class StockCompanyInfoData {
+  final String sector;
+  final String debtRatio;
+  final String netProfitMargin;
+  final String market;
+  final String description;
+
+  const StockCompanyInfoData({
+    required this.sector,
+    required this.debtRatio,
+    required this.netProfitMargin,
+    required this.market,
+    required this.description,
+  });
+}
+
+/// 종목 상세 - 개요 탭의 '기업 정보' 카드 위젯
+class StockCompanyInfoCard extends StatelessWidget {
+  final StockCompanyInfoData data;
+
+  const StockCompanyInfoCard({super.key, required this.data});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 20),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: Colors.grey[200]!),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('기업 정보', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 16),
+          // 2x2 그리드
+          Table(
+            children: [
+              TableRow(
+                children: [
+                  _buildInfoItem('분야', data.sector),
+                  _buildInfoItem('시장 구분', data.market),
+                ],
+              ),
+              TableRow(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(top: 16.0),
+                    child: _buildInfoItem('부채비율', data.debtRatio),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.only(top: 16.0),
+                    child: _buildInfoItem('순이익률', data.netProfitMargin),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          const Padding(
+            padding: EdgeInsets.symmetric(vertical: 16.0),
+            child: Divider(),
+          ),
+          // 기업 소개
+          Text(
+            data.description,
+            style: TextStyle(fontSize: 14, color: Colors.grey[800], height: 1.5),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // 그리드 아이템 위젯
+  Widget _buildInfoItem(String title, String value) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: TextStyle(fontSize: 13, color: Colors.grey[600])),
+        const SizedBox(height: 4),
+        Text(value, style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500)),
+      ],
+    );
+  }
+}

--- a/lib/features/stock_detail/presentation/widget/stock_header.dart
+++ b/lib/features/stock_detail/presentation/widget/stock_header.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+
+// 위젯에 전달될 데이터 모델
+class StockHeaderData {
+  final String name;
+  final String code;
+  final int currentPrice;
+  final int change;
+  final double changeRate;
+  final int volume;
+  final int prevClose;
+  final String market;
+
+  const StockHeaderData({
+    required this.name,
+    required this.code,
+    required this.currentPrice,
+    required this.change,
+    required this.changeRate,
+    required this.volume,
+    required this.prevClose,
+    required this.market,
+  });
+}
+
+/// 종목 상세 - 개요 탭의 헤더 위젯
+class StockHeader extends StatelessWidget {
+  final StockHeaderData data;
+
+  const StockHeader({super.key, required this.data});
+
+  @override
+  Widget build(BuildContext context) {
+    final isUp = data.changeRate >= 0;
+    final rateColor = isUp ? Colors.red : Colors.blue;
+    final rateIcon = isUp ? Icons.arrow_drop_up : Icons.arrow_drop_down;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 1. 종목명, 종목코드
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.baseline,
+            textBaseline: TextBaseline.alphabetic,
+            children: [
+              Text(data.name, style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold)),
+              const SizedBox(width: 8),
+              Text(data.code, style: const TextStyle(fontSize: 16, color: Colors.grey)),
+            ],
+          ),
+          const SizedBox(height: 12),
+          // 2. 현재가, 등락 정보
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: [
+              Text('${data.currentPrice}', style: const TextStyle(fontSize: 36, fontWeight: FontWeight.bold)),
+              // KOSDAQ/KOSPI 정보
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  color: Colors.grey[200],
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Text(data.market, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 12)),
+              )
+            ],
+          ),
+          const SizedBox(height: 8),
+          // 3. 등락률, 전일가, 거래량
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Row(
+                children: [
+                  Icon(rateIcon, color: rateColor, size: 24),
+                  Text('${data.change}', style: TextStyle(color: rateColor, fontWeight: FontWeight.bold, fontSize: 16)),
+                  const SizedBox(width: 4),
+                  Text('(${data.changeRate.toStringAsFixed(2)}%)', style: TextStyle(color: rateColor, fontSize: 16)),
+                ],
+              ),
+              Text('거래량 ${data.volume}', style: const TextStyle(color: Colors.grey, fontSize: 12)),
+            ],
+          ),
+          const SizedBox(height: 4),
+          Text('전일가 ${data.prevClose}', style: const TextStyle(color: Colors.grey, fontSize: 12)),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/stock_detail/presentation/widget/stock_header.dart
+++ b/lib/features/stock_detail/presentation/widget/stock_header.dart
@@ -29,6 +29,15 @@ class StockHeader extends StatelessWidget {
 
   const StockHeader({super.key, required this.data});
 
+  // [핵심 추가] 거래량을 M(백만) 단위로 포맷하는 함수
+  String _formatVolume(int volume) {
+    if (volume < 1000000) {
+      return volume.toString();
+    }
+    double newVolume = volume / 1000000.0;
+    return '${newVolume.toStringAsFixed(1)}M';
+  }
+
   @override
   Widget build(BuildContext context) {
     final isUp = data.changeRate >= 0;
@@ -51,13 +60,12 @@ class StockHeader extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 12),
-          // 2. 현재가, 등락 정보
+          // 2. 현재가, KOSDAQ 배지
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             crossAxisAlignment: CrossAxisAlignment.end,
             children: [
               Text('${data.currentPrice}', style: const TextStyle(fontSize: 36, fontWeight: FontWeight.bold)),
-              // KOSDAQ/KOSPI 정보
               Container(
                 padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                 decoration: BoxDecoration(
@@ -69,23 +77,24 @@ class StockHeader extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 8),
-          // 3. 등락률, 전일가, 거래량
+          // 3. 등락률
           Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Row(
-                children: [
-                  Icon(rateIcon, color: rateColor, size: 24),
-                  Text('${data.change}', style: TextStyle(color: rateColor, fontWeight: FontWeight.bold, fontSize: 16)),
-                  const SizedBox(width: 4),
-                  Text('(${data.changeRate.toStringAsFixed(2)}%)', style: TextStyle(color: rateColor, fontSize: 16)),
-                ],
-              ),
-              Text('거래량 ${data.volume}', style: const TextStyle(color: Colors.grey, fontSize: 12)),
+              Icon(rateIcon, color: rateColor, size: 24),
+              Text('${data.change}', style: TextStyle(color: rateColor, fontWeight: FontWeight.bold, fontSize: 16)),
+              const SizedBox(width: 4),
+              Text('(${data.changeRate.toStringAsFixed(2)}%)', style: TextStyle(color: rateColor, fontSize: 16)),
             ],
           ),
-          const SizedBox(height: 4),
-          Text('전일가 ${data.prevClose}', style: const TextStyle(color: Colors.grey, fontSize: 12)),
+          const SizedBox(height: 8),
+          // [핵심 수정] 4. 전일가와 거래량을 한 줄에 표시
+          Row(
+            children: [
+              Text('전일 ${data.prevClose}', style: const TextStyle(color: Colors.grey, fontSize: 12, fontWeight: FontWeight.w600)),
+              const Text('  ·  ', style: TextStyle(color: Colors.grey, fontSize: 12)),
+              Text('거래량 ${_formatVolume(data.volume)}', style: const TextStyle(color: Colors.grey, fontSize: 12, fontWeight: FontWeight.w600)),
+            ],
+          )
         ],
       ),
     );


### PR DESCRIPTION
## 📌 Issue number and Link
  closed #13 


## 📝 Changes
- 종목 상세 페이지(StockDetailPage) 추가: 하단에 개요, 일별시세, 재무, 뉴스/공시 4개의 탭을 가진 페이지의 기본 구조를 만들었습니다.
- 개요 탭 UI 구현: 기획에 맞춰 아래의 위젯들을 조합하여 개요 탭 UI 전체를 구현했습니다.
  - StockHeader: 주가, 등락률, 거래량 등 핵심 정보를 표시합니다.
  - StockChartCard: CustomPainter를 이용해 6개월치 주가/거래량 차트 시안을 구현했습니다.
  - StockBasicInfoCard: 시가총액, PER, ROE 등 기본 투자 지표를 표시합니다.
  - StockCompanyInfoCard: 분야, 시장, 기업 소개 등 요약 정보를 보여줍니다.
  
- 라우팅 연결: 검색 결과의 종목을 탭하면, 해당 종목 코드를 가지고 새로 만든 상세 페이지로 이동하도록 연결했습니다.


## 🔎 PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot
<img width="413" height="871" alt="image" src="https://github.com/user-attachments/assets/da6c068b-88e7-4262-8816-285dbcaa8d0c" />
<img width="409" height="863" alt="image" src="https://github.com/user-attachments/assets/df219b8f-fe08-4099-8542-1c29c7fbd2db" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **New Features**
  * 주식 상세 페이지 추가: 종목코드로 접근 가능한 새로운 상세 정보 화면 제공
  * 주식 정보 탭 구성: 개요, 일일 가격, 재무, 뉴스 공시 탭으로 정보 구성
  * 주식 헤더 위젯 추가: 현재가, 변동률, 거래량, 이전 종가 표시
  * 주식 차트 카드 추가: 가격 추이 및 거래량 시각화
  * 주식 기본 정보 카드 추가: 시가총액, P/E, ROE, 배당수익률, 52주 범위 표시
  * 기업 정보 카드 추가: 업종, 부채비율, 순이익률, 시장 구분, 기업 소개 제공
  * 스크리너 결과에서 종목 상세 페이지로 직접 이동 기능 연결

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->