### PR TITLE
[FEATURE] 종목 상세 페이지-일별시세 UI 구현

### DIFF
--- a/lib/features/stock_detail/presentation/stock_detail_page.dart
+++ b/lib/features/stock_detail/presentation/stock_detail_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/daily_price_tab.dart';
 import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/overview_tab.dart';
 
 class StockDetailPage extends StatefulWidget {
@@ -21,7 +22,6 @@ class _StockDetailPageState extends State<StockDetailPage> {
 
     return Scaffold(
       appBar: AppBar(
-        // [핵심 수정] AppBar에 종목명만 표시하도록 변경
         title: Text(
           '$stockName (${widget.stockCode})',
           style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
@@ -32,7 +32,8 @@ class _StockDetailPageState extends State<StockDetailPage> {
         index: _selectedTabIndex,
         children: const [
           OverviewTab(),
-          Center(child: Text('일별시세 탭 콘텐츠')),
+          // '일별시세' 탭의 내용을 DailyPriceTab 위젯으로 교체
+          DailyPriceTab(),
           Center(child: Text('재무 탭 콘텐츠')),
           Center(child: Text('뉴스/공시 탭 콘텐츠')),
         ],

--- a/lib/features/stock_detail/presentation/widget/daily_price_tab.dart
+++ b/lib/features/stock_detail/presentation/widget/daily_price_tab.dart
@@ -1,0 +1,324 @@
+import 'package:flutter/material.dart';
+
+// 일별시세 데이터 모델
+class DailyPriceData {
+  final String date;      // "04.05"
+  final int closePrice;   // 19070
+  final int change;       // -640
+  final double changeRate;// -3.00
+  final int volume;       // 4265988
+
+  const DailyPriceData({
+    required this.date,
+    required this.closePrice,
+    required this.change,
+    required this.changeRate,
+    required this.volume,
+  });
+}
+
+/// 종목 상세 - '일별시세' 탭 위젯
+class DailyPriceTab extends StatefulWidget {
+  const DailyPriceTab({super.key});
+
+  @override
+  State<DailyPriceTab> createState() => _DailyPriceTabState();
+}
+
+class _DailyPriceTabState extends State<DailyPriceTab> {
+  final List<DailyPriceData> _dailyPrices = [];
+  final ScrollController _scrollController = ScrollController();
+  bool _loading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadMoreData();
+
+    _scrollController.addListener(() {
+      if (_scrollController.position.pixels >= _scrollController.position.maxScrollExtent - 80) {
+        _loadMoreData();
+      }
+    });
+  }
+
+  Future<void> _loadMoreData() async {
+    if (_loading) return;
+    _loading = true;
+
+    // 서버에서 데이터를 가져오는 것을 시뮬레이션
+    await Future.delayed(const Duration(milliseconds: 200));
+
+    final List<DailyPriceData> newItems = List.generate(20, (index) {
+      final sign = index % 3 == 0 ? -1 : 1;
+      return DailyPriceData(
+        date: '04.${(5 - index % 5).toString().padLeft(2, '0')}',
+        closePrice: 19070 + (index * 100 * sign),
+        change: -640 + (index * 50 * sign),
+        changeRate: -3.00 + (index * 0.5 * sign),
+        volume: 4265988 + (index * 10000),
+      );
+    });
+
+    if (!mounted) return;
+    setState(() => _dailyPrices.addAll(newItems));
+    _loading = false;
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      children: [
+        _DailyHeader(theme: theme),
+        Expanded(
+          child: ListView.separated(
+            controller: _scrollController,
+            itemCount: _dailyPrices.length + 1, // +1: 로딩 인디케이터 영역
+            itemBuilder: (context, index) {
+              if (index == _dailyPrices.length) {
+                // 바닥 로딩
+                return Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  child: Center(
+                    child: Opacity(
+                      opacity: 0.6,
+                      child: _loading ? const SizedBox(height: 18, width: 18, child: CircularProgressIndicator(strokeWidth: 2))
+                          : const SizedBox.shrink(),
+                    ),
+                  ),
+                );
+              }
+              return _DailyPriceRow(data: _dailyPrices[index]);
+            },
+            separatorBuilder: (context, index) => Divider(
+              height: 1,
+              thickness: 1,
+              color: theme.dividerColor.withOpacity(0.10),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// 상단 헤더 (목표 UI처럼 밝은 배경 + 얇은 구분선)
+class _DailyHeader extends StatelessWidget {
+  final ThemeData theme;
+  const _DailyHeader({required this.theme});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 10),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface.withOpacity(0.65),
+        border: Border(
+          bottom: BorderSide(color: theme.dividerColor.withOpacity(0.15)),
+        ),
+      ),
+      child: const Row(
+        children: [
+          Expanded(flex: 2, child: _HeaderText('날짜', align: TextAlign.left)),
+          Expanded(flex: 3, child: _HeaderText('종가', align: TextAlign.right)),
+          Expanded(flex: 4, child: _HeaderText('전일대비', align: TextAlign.right)),
+          Expanded(flex: 4, child: _HeaderText('거래량', align: TextAlign.right)),
+        ],
+      ),
+    );
+  }
+}
+
+class _HeaderText extends StatelessWidget {
+  final String text;
+  final TextAlign align;
+  const _HeaderText(this.text, {required this.align});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Text(
+      text,
+      textAlign: align,
+      style: theme.textTheme.labelLarge?.copyWith(
+        fontWeight: FontWeight.w800,
+        color: theme.hintColor.withOpacity(0.90),
+      ),
+    );
+  }
+}
+
+/// 일별시세 데이터 한 줄 (목표 UI처럼 "전일대비"를 한 줄로 정리 + 퍼센트는 보조)
+class _DailyPriceRow extends StatelessWidget {
+  final DailyPriceData data;
+
+  const _DailyPriceRow({required this.data});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    final isUp = data.change > 0;
+    final isDown = data.change < 0;
+
+    // 목표 UI처럼 "상승=빨강, 하락=파랑" 유지
+    final Color color = isUp
+        ? const Color(0xFFFF6B6B) // 살짝 톤다운 레드
+        : isDown
+        ? const Color(0xFF4D96FF) // 톤다운 블루
+        : theme.colorScheme.onSurface.withOpacity(0.55);
+
+    final IconData icon = isUp
+        ? Icons.arrow_drop_up
+        : isDown
+        ? Icons.arrow_drop_down
+        : Icons.remove;
+
+    final String changeText = _formatSignedInt(data.change); // +575 / -640
+    final String priceText = '${_formatInt(data.closePrice)}원';
+    final String volumeText = _formatInt(data.volume);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Row(
+        children: [
+          // 날짜
+          Expanded(
+            flex: 2,
+            child: Text(
+              data.date,
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: theme.colorScheme.onSurface.withOpacity(0.85),
+                fontWeight: FontWeight.w400,
+              ),
+            ),
+          ),
+
+          // 종가
+          Expanded(
+            flex: 3,
+            child: Text(
+              priceText,
+              textAlign: TextAlign.right,
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w500,
+                letterSpacing: -0.2,
+              ),
+            ),
+          ),
+
+          // 전일대비: (아이콘 + 등락값) + (퍼센트)
+          Expanded(
+            flex: 4,
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: _ChangeBlock(
+                theme: theme,
+                color: color,
+                icon: icon,
+                changeText: changeText,
+                rateText: '(${_formatSignedRate(data.changeRate)}%)',
+              ),
+            ),
+          ),
+
+          // 거래량
+          Expanded(
+            flex: 4,
+            child: Text(
+              volumeText,
+              textAlign: TextAlign.right,
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: theme.colorScheme.onSurface.withOpacity(0.78),
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // 4265988 -> 4,265,988
+  String _formatInt(int n) {
+    final s = n.toString();
+    final buf = StringBuffer();
+    for (int i = 0; i < s.length; i++) {
+      final posFromEnd = s.length - i;
+      buf.write(s[i]);
+      if (posFromEnd > 1 && posFromEnd % 3 == 1) buf.write(',');
+    }
+    return buf.toString();
+  }
+
+  // +575 / -640 / 0
+  String _formatSignedInt(int n) {
+    if (n > 0) return '+${_formatInt(n)}';
+    if (n < 0) return '-${_formatInt(n.abs())}';
+    return '0';
+  }
+
+  // +3.00 / -2.50 / 0.00
+  String _formatSignedRate(double r) {
+    if (r > 0) return '+${r.toStringAsFixed(2)}';
+    if (r < 0) return r.toStringAsFixed(2); // 이미 음수 부호 포함
+    return '0.00';
+  }
+}
+
+class _ChangeBlock extends StatelessWidget {
+  final ThemeData theme;
+  final Color color;
+  final IconData icon;
+  final String changeText;
+  final String rateText;
+
+  const _ChangeBlock({
+    required this.theme,
+    required this.color,
+    required this.icon,
+    required this.changeText,
+    required this.rateText,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    // 목표 UI처럼 "등락값은 메인, 퍼센트는 서브" + 정렬 깔끔히
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, color: color, size: 18),
+            const SizedBox(width: 2),
+            Text(
+              changeText,
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: color,
+                fontWeight: FontWeight.w800,
+                letterSpacing: -0.2,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 3),
+        Text(
+          rateText,
+          style: theme.textTheme.labelMedium?.copyWith(
+            color: color.withOpacity(0.75),
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/stock_detail/presentation/widget/daily_price_tab.dart
+++ b/lib/features/stock_detail/presentation/widget/daily_price_tab.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart'; // [핵심 추가]
 
 // 일별시세 데이터 모델
 class DailyPriceData {
-  final String date;      // "04.05"
-  final int closePrice;   // 19070
-  final int change;       // -640
-  final double changeRate;// -3.00
-  final int volume;       // 4265988
+  final String date;
+  final int closePrice;
+  final int change;
+  final double changeRate;
+  final int volume;
 
   const DailyPriceData({
     required this.date,
@@ -44,9 +45,8 @@ class _DailyPriceTabState extends State<DailyPriceTab> {
 
   Future<void> _loadMoreData() async {
     if (_loading) return;
-    _loading = true;
+    setState(() => _loading = true);
 
-    // 서버에서 데이터를 가져오는 것을 시뮬레이션
     await Future.delayed(const Duration(milliseconds: 200));
 
     final List<DailyPriceData> newItems = List.generate(20, (index) {
@@ -61,8 +61,10 @@ class _DailyPriceTabState extends State<DailyPriceTab> {
     });
 
     if (!mounted) return;
-    setState(() => _dailyPrices.addAll(newItems));
-    _loading = false;
+    setState(() {
+      _dailyPrices.addAll(newItems);
+      _loading = false;
+    });
   }
 
   @override
@@ -81,17 +83,15 @@ class _DailyPriceTabState extends State<DailyPriceTab> {
         Expanded(
           child: ListView.separated(
             controller: _scrollController,
-            itemCount: _dailyPrices.length + 1, // +1: 로딩 인디케이터 영역
+            itemCount: _dailyPrices.length + (_loading ? 1 : 0),
             itemBuilder: (context, index) {
               if (index == _dailyPrices.length) {
-                // 바닥 로딩
                 return Padding(
                   padding: const EdgeInsets.symmetric(vertical: 14),
                   child: Center(
                     child: Opacity(
                       opacity: 0.6,
-                      child: _loading ? const SizedBox(height: 18, width: 18, child: CircularProgressIndicator(strokeWidth: 2))
-                          : const SizedBox.shrink(),
+                      child: const SizedBox(height: 18, width: 18, child: CircularProgressIndicator(strokeWidth: 2)),
                     ),
                   ),
                 );
@@ -101,7 +101,7 @@ class _DailyPriceTabState extends State<DailyPriceTab> {
             separatorBuilder: (context, index) => Divider(
               height: 1,
               thickness: 1,
-              color: theme.dividerColor.withOpacity(0.10),
+              color: theme.dividerColor.withAlpha((0.10 * 255).round()),
             ),
           ),
         ),
@@ -110,7 +110,6 @@ class _DailyPriceTabState extends State<DailyPriceTab> {
   }
 }
 
-/// 상단 헤더 (목표 UI처럼 밝은 배경 + 얇은 구분선)
 class _DailyHeader extends StatelessWidget {
   final ThemeData theme;
   const _DailyHeader({required this.theme});
@@ -120,10 +119,8 @@ class _DailyHeader extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.fromLTRB(16, 12, 16, 10),
       decoration: BoxDecoration(
-        color: theme.colorScheme.surface.withOpacity(0.65),
-        border: Border(
-          bottom: BorderSide(color: theme.dividerColor.withOpacity(0.15)),
-        ),
+        color: theme.colorScheme.surface.withAlpha((0.65 * 255).round()),
+        border: Border(bottom: BorderSide(color: theme.dividerColor.withAlpha((0.15 * 255).round()))),
       ),
       child: const Row(
         children: [
@@ -150,13 +147,12 @@ class _HeaderText extends StatelessWidget {
       textAlign: align,
       style: theme.textTheme.labelLarge?.copyWith(
         fontWeight: FontWeight.w800,
-        color: theme.hintColor.withOpacity(0.90),
+        color: theme.hintColor.withAlpha((0.90 * 255).round()),
       ),
     );
   }
 }
 
-/// 일별시세 데이터 한 줄 (목표 UI처럼 "전일대비"를 한 줄로 정리 + 퍼센트는 보조)
 class _DailyPriceRow extends StatelessWidget {
   final DailyPriceData data;
 
@@ -165,24 +161,12 @@ class _DailyPriceRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-
     final isUp = data.change > 0;
     final isDown = data.change < 0;
+    final Color color = isUp ? const Color(0xFFFF6B6B) : (isDown ? const Color(0xFF4D96FF) : theme.colorScheme.onSurface.withAlpha((0.55 * 255).round()));
+    final IconData icon = isUp ? Icons.arrow_drop_up : (isDown ? Icons.arrow_drop_down : Icons.remove);
 
-    // 목표 UI처럼 "상승=빨강, 하락=파랑" 유지
-    final Color color = isUp
-        ? const Color(0xFFFF6B6B) // 살짝 톤다운 레드
-        : isDown
-        ? const Color(0xFF4D96FF) // 톤다운 블루
-        : theme.colorScheme.onSurface.withOpacity(0.55);
-
-    final IconData icon = isUp
-        ? Icons.arrow_drop_up
-        : isDown
-        ? Icons.arrow_drop_down
-        : Icons.remove;
-
-    final String changeText = _formatSignedInt(data.change); // +575 / -640
+    final String changeText = _formatSignedInt(data.change);
     final String priceText = '${_formatInt(data.closePrice)}원';
     final String volumeText = _formatInt(data.volume);
 
@@ -190,87 +174,44 @@ class _DailyPriceRow extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       child: Row(
         children: [
-          // 날짜
           Expanded(
             flex: 2,
-            child: Text(
-              data.date,
-              style: theme.textTheme.bodyLarge?.copyWith(
-                color: theme.colorScheme.onSurface.withOpacity(0.85),
-                fontWeight: FontWeight.w400,
-              ),
-            ),
+            child: Text(data.date, style: theme.textTheme.bodyLarge?.copyWith(color: theme.colorScheme.onSurface.withAlpha((0.85 * 255).round()), fontWeight: FontWeight.w400)),
           ),
-
-          // 종가
           Expanded(
             flex: 3,
-            child: Text(
-              priceText,
-              textAlign: TextAlign.right,
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.w500,
-                letterSpacing: -0.2,
-              ),
-            ),
+            child: Text(priceText, textAlign: TextAlign.right, style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w500, letterSpacing: -0.2)),
           ),
-
-          // 전일대비: (아이콘 + 등락값) + (퍼센트)
           Expanded(
             flex: 4,
             child: Align(
               alignment: Alignment.centerRight,
-              child: _ChangeBlock(
-                theme: theme,
-                color: color,
-                icon: icon,
-                changeText: changeText,
-                rateText: '(${_formatSignedRate(data.changeRate)}%)',
-              ),
+              child: _ChangeBlock(theme: theme, color: color, icon: icon, changeText: changeText, rateText: '(${_formatSignedRate(data.changeRate)}%)'),
             ),
           ),
-
-          // 거래량
           Expanded(
             flex: 4,
-            child: Text(
-              volumeText,
-              textAlign: TextAlign.right,
-              style: theme.textTheme.bodyLarge?.copyWith(
-                color: theme.colorScheme.onSurface.withOpacity(0.78),
-                fontWeight: FontWeight.w500,
-              ),
-            ),
+            child: Text(volumeText, textAlign: TextAlign.right, style: theme.textTheme.bodyLarge?.copyWith(color: theme.colorScheme.onSurface.withAlpha((0.78 * 255).round()), fontWeight: FontWeight.w500)),
           ),
         ],
       ),
     );
   }
 
-  // 4265988 -> 4,265,988
+  // [핵심 수정] intl 패키지를 사용하여 숫자 포맷팅
   String _formatInt(int n) {
-    final s = n.toString();
-    final buf = StringBuffer();
-    for (int i = 0; i < s.length; i++) {
-      final posFromEnd = s.length - i;
-      buf.write(s[i]);
-      if (posFromEnd > 1 && posFromEnd % 3 == 1) buf.write(',');
-    }
-    return buf.toString();
+    return NumberFormat('#,###').format(n);
   }
 
-  // +575 / -640 / 0
   String _formatSignedInt(int n) {
     if (n > 0) return '+${_formatInt(n)}';
-    if (n < 0) return '-${_formatInt(n.abs())}';
+    if (n < 0) return '${_formatInt(n)}';
     return '0';
   }
 
-  // +3.00 / -2.50 / 0.00
   String _formatSignedRate(double r) {
     if (r > 0) return '+${r.toStringAsFixed(2)}';
-    if (r < 0) return r.toStringAsFixed(2); // 이미 음수 부호 포함
-    return '0.00';
+    return r.toStringAsFixed(2);
   }
 }
 
@@ -291,7 +232,6 @@ class _ChangeBlock extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // 목표 UI처럼 "등락값은 메인, 퍼센트는 서브" + 정렬 깔끔히
     return Column(
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
@@ -300,24 +240,11 @@ class _ChangeBlock extends StatelessWidget {
           children: [
             Icon(icon, color: color, size: 18),
             const SizedBox(width: 2),
-            Text(
-              changeText,
-              style: theme.textTheme.titleMedium?.copyWith(
-                color: color,
-                fontWeight: FontWeight.w800,
-                letterSpacing: -0.2,
-              ),
-            ),
+            Text(changeText, style: theme.textTheme.titleMedium?.copyWith(color: color, fontWeight: FontWeight.w800, letterSpacing: -0.2)),
           ],
         ),
         const SizedBox(height: 3),
-        Text(
-          rateText,
-          style: theme.textTheme.labelMedium?.copyWith(
-            color: color.withOpacity(0.75),
-            fontWeight: FontWeight.w600,
-          ),
-        ),
+        Text(rateText, style: theme.textTheme.labelMedium?.copyWith(color: color.withAlpha((0.75 * 255).round()), fontWeight: FontWeight.w600)),
       ],
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -88,6 +88,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "14.8.1"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,8 @@ dependencies:
   flutter:
     sdk: flutter
 
+  intl: ^0.19.0
+
   cupertino_icons: ^1.0.8
   go_router: ^14.2.0
 


### PR DESCRIPTION
## 📌 Issue number and Link
  closed #15 


## 📝 Changes
- 일별시세 탭 UI 구현: 날짜, 종가, 전일대비, 거래량 정보를 조합해 일별시세 탭을 구현했습니다.
  - 20개씩 끊어서 정보를 보여주는 무한 스크롤 방식으로 구현했습니다.


## 🔎 PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 주식 상세 페이지의 일별시세 탭에 실제 가격 데이터 표시 기능 추가
  * 스크롤 시 추가 데이터를 자동으로 로드하는 지연 로딩 구현
  * 날짜, 종가, 변동, 변동률, 거래량 정보를 시각적으로 표시
  * 상승/하락 여부를 색상으로 구분하여 표시

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->