### PR TITLE
[FEATURE] 종목 상세 페이지-재무 UI 구현

### DIFF
--- a/lib/features/stock_detail/presentation/stock_detail_page.dart
+++ b/lib/features/stock_detail/presentation/stock_detail_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/daily_price_tab.dart';
+import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/financials_tab.dart';
 import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/overview_tab.dart';
 
 class StockDetailPage extends StatefulWidget {
@@ -32,9 +33,9 @@ class _StockDetailPageState extends State<StockDetailPage> {
         index: _selectedTabIndex,
         children: const [
           OverviewTab(),
-          // '일별시세' 탭의 내용을 DailyPriceTab 위젯으로 교체
           DailyPriceTab(),
-          Center(child: Text('재무 탭 콘텐츠')),
+          // '재무' 탭의 내용을 FinancialsTab 위젯으로 교체
+          FinancialsTab(),
           Center(child: Text('뉴스/공시 탭 콘텐츠')),
         ],
       ),

--- a/lib/features/stock_detail/presentation/stock_detail_page.dart
+++ b/lib/features/stock_detail/presentation/stock_detail_page.dart
@@ -31,12 +31,14 @@ class _StockDetailPageState extends State<StockDetailPage> {
       ),
       body: IndexedStack(
         index: _selectedTabIndex,
-        children: const [
-          OverviewTab(),
-          DailyPriceTab(),
-          // '재무' 탭의 내용을 FinancialsTab 위젯으로 교체
-          FinancialsTab(),
-          Center(child: Text('뉴스/공시 탭 콘텐츠')),
+        children: [
+          const OverviewTab(),
+          const DailyPriceTab(),
+          FinancialsTab(
+            stockName: stockName,
+            stockCode: widget.stockCode,
+          ),
+          const Center(child: Text('뉴스/공시 탭 콘텐츠')),
         ],
       ),
       bottomNavigationBar: _buildBottomNavigationBar(),

--- a/lib/features/stock_detail/presentation/widget/financial_stability_card.dart
+++ b/lib/features/stock_detail/presentation/widget/financial_stability_card.dart
@@ -20,9 +20,9 @@ class FinancialStabilityData {
 
   // 부채비율 계산 (부채 / 자본 * 100)
   double get debtRatio {
-    if (totalEquityVal <= 0) return 0.0;  // 또는 적절한 기본값
-      return (totalLiabilitiesVal / totalEquityVal) * 100;
-    }
+    if (totalEquityVal <= 0) return 0.0;  // 자본잠식 또는 0일때 0.0 반환
+    return (totalLiabilitiesVal / totalEquityVal) * 100;
+  }
 }
 
 class FinancialStabilityCard extends StatelessWidget {
@@ -32,22 +32,27 @@ class FinancialStabilityCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // 테마 컬러 설정 (앱의 브랜드 컬러에 맞게 조정하세요)
-    // 부채는 약간 경고 느낌(주황/빨강) 혹은 중립(회색), 자본은 긍정(파랑/초록) 추천
     final liabilityColor = Colors.orange.shade300;
     final equityColor = Colors.blue.shade300;
 
-    // 전체 자산 대비 비율 계산 (Flex에 넣기 위함)
+    // [핵심 수정] 0으로 나누기 오류 방지
     final total = data.totalLiabilitiesVal + data.totalEquityVal;
-    // 소수점 문제 방지를 위해 정수 Flex 값으로 변환
-    final int liabilityFlex = ((data.totalLiabilitiesVal / total) * 100).round();
-    final int equityFlex = 100 - liabilityFlex;
+    int liabilityFlex;
+    int equityFlex;
+
+    if (total == 0) {
+      liabilityFlex = 50;
+      equityFlex = 50;
+    } else {
+      liabilityFlex = ((data.totalLiabilitiesVal / total) * 100).round();
+      equityFlex = 100 - liabilityFlex;
+    }
 
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
-        color: Colors.white, // 카드 배경
+        color: Colors.white,
         borderRadius: BorderRadius.circular(20),
         boxShadow: [
           BoxShadow(
@@ -60,7 +65,6 @@ class FinancialStabilityCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // 1. 헤더 (제목 + 부채비율 뱃지)
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
@@ -72,53 +76,34 @@ class FinancialStabilityCard extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 24),
-
-          // 2. 핵심 시각화 (Stacked Bar Graph)
-          // "자산 = 부채 + 자본"을 하나의 막대로 표현
           ClipRRect(
             borderRadius: BorderRadius.circular(10),
             child: SizedBox(
-              height: 24, // 막대 두께
+              height: 24,
               child: Row(
                 children: [
-                  // 부채 영역
                   Expanded(
                     flex: liabilityFlex,
-                    child: Container(
-                      color: liabilityColor,
-                      alignment: Alignment.centerLeft,
-                      padding: const EdgeInsets.only(left: 8),
-                      // 공간이 좁으면 텍스트 숨김 처리 등을 해야 할 수도 있음
-                    ),
+                    child: Container(color: liabilityColor),
                   ),
-                  // 자본 영역
                   Expanded(
                     flex: equityFlex,
-                    child: Container(
-                      color: equityColor,
-                      alignment: Alignment.centerRight,
-                      padding: const EdgeInsets.only(right: 8),
-                    ),
+                    child: Container(color: equityColor),
                   ),
                 ],
               ),
             ),
           ),
-
           const SizedBox(height: 12),
-
-          // 3. 하단 상세 정보 (범례 역할)
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              // 부채 정보
               _buildLegendItem(
                 title: "부채총계",
                 value: data.totalLiabilitiesStr,
                 color: liabilityColor,
                 align: CrossAxisAlignment.start,
               ),
-              // 자본 정보
               _buildLegendItem(
                 title: "자본총계",
                 value: data.totalEquityStr,
@@ -127,12 +112,9 @@ class FinancialStabilityCard extends StatelessWidget {
               ),
             ],
           ),
-
           const SizedBox(height: 20),
           Divider(color: Colors.grey.withOpacity(0.2)),
           const SizedBox(height: 12),
-
-          // 4. 자산 총계 (결론)
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
@@ -148,7 +130,6 @@ class FinancialStabilityCard extends StatelessWidget {
     );
   }
 
-  // 부채비율 상태 뱃지
   Widget _buildDebtRatioBadge(double ratio) {
     Color color;
     String text;
@@ -185,7 +166,6 @@ class FinancialStabilityCard extends StatelessWidget {
     );
   }
 
-  // 하단 범례 아이템
   Widget _buildLegendItem({
     required String title,
     required String value,

--- a/lib/features/stock_detail/presentation/widget/financial_stability_card.dart
+++ b/lib/features/stock_detail/presentation/widget/financial_stability_card.dart
@@ -1,0 +1,214 @@
+import 'package:flutter/material.dart';
+
+// 데이터 모델 (비율 계산을 위해 double 타입 추가)
+class FinancialStabilityData {
+  final String totalAssetsStr;      // 화면 표시용 (예: "4,567억")
+  final String totalLiabilitiesStr; // 화면 표시용 (예: "2,989억")
+  final String totalEquityStr;      // 화면 표시용 (예: "1,578억")
+
+  // 그래프 비율 계산용 실제 숫자 (단위 상관 없음, 비율만 맞으면 됨)
+  final double totalLiabilitiesVal;
+  final double totalEquityVal;
+
+  const FinancialStabilityData({
+    required this.totalAssetsStr,
+    required this.totalLiabilitiesStr,
+    required this.totalEquityStr,
+    required this.totalLiabilitiesVal,
+    required this.totalEquityVal,
+  });
+
+  // 부채비율 계산 (부채 / 자본 * 100)
+  double get debtRatio => (totalLiabilitiesVal / totalEquityVal) * 100;
+}
+
+class FinancialStabilityCard extends StatelessWidget {
+  final FinancialStabilityData data;
+
+  const FinancialStabilityCard({super.key, required this.data});
+
+  @override
+  Widget build(BuildContext context) {
+    // 테마 컬러 설정 (앱의 브랜드 컬러에 맞게 조정하세요)
+    // 부채는 약간 경고 느낌(주황/빨강) 혹은 중립(회색), 자본은 긍정(파랑/초록) 추천
+    final liabilityColor = Colors.orange.shade300;
+    final equityColor = Colors.blue.shade300;
+
+    // 전체 자산 대비 비율 계산 (Flex에 넣기 위함)
+    final total = data.totalLiabilitiesVal + data.totalEquityVal;
+    // 소수점 문제 방지를 위해 정수 Flex 값으로 변환
+    final int liabilityFlex = ((data.totalLiabilitiesVal / total) * 100).round();
+    final int equityFlex = 100 - liabilityFlex;
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: Colors.white, // 카드 배경
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.grey.withOpacity(0.1),
+            blurRadius: 10,
+            spreadRadius: 2,
+          )
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 1. 헤더 (제목 + 부채비율 뱃지)
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                '재무 안전성',
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              ),
+              _buildDebtRatioBadge(data.debtRatio),
+            ],
+          ),
+          const SizedBox(height: 24),
+
+          // 2. 핵심 시각화 (Stacked Bar Graph)
+          // "자산 = 부채 + 자본"을 하나의 막대로 표현
+          ClipRRect(
+            borderRadius: BorderRadius.circular(10),
+            child: SizedBox(
+              height: 24, // 막대 두께
+              child: Row(
+                children: [
+                  // 부채 영역
+                  Expanded(
+                    flex: liabilityFlex,
+                    child: Container(
+                      color: liabilityColor,
+                      alignment: Alignment.centerLeft,
+                      padding: const EdgeInsets.only(left: 8),
+                      // 공간이 좁으면 텍스트 숨김 처리 등을 해야 할 수도 있음
+                    ),
+                  ),
+                  // 자본 영역
+                  Expanded(
+                    flex: equityFlex,
+                    child: Container(
+                      color: equityColor,
+                      alignment: Alignment.centerRight,
+                      padding: const EdgeInsets.only(right: 8),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+
+          const SizedBox(height: 12),
+
+          // 3. 하단 상세 정보 (범례 역할)
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              // 부채 정보
+              _buildLegendItem(
+                title: "부채총계",
+                value: data.totalLiabilitiesStr,
+                color: liabilityColor,
+                align: CrossAxisAlignment.start,
+              ),
+              // 자본 정보
+              _buildLegendItem(
+                title: "자본총계",
+                value: data.totalEquityStr,
+                color: equityColor,
+                align: CrossAxisAlignment.end,
+              ),
+            ],
+          ),
+
+          const SizedBox(height: 20),
+          Divider(color: Colors.grey.withOpacity(0.2)),
+          const SizedBox(height: 12),
+
+          // 4. 자산 총계 (결론)
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text("자산총계 (부채+자본)", style: TextStyle(color: Colors.grey[600], fontSize: 13)),
+              Text(
+                  data.totalAssetsStr,
+                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16)
+              ),
+            ],
+          )
+        ],
+      ),
+    );
+  }
+
+  // 부채비율 상태 뱃지
+  Widget _buildDebtRatioBadge(double ratio) {
+    Color color;
+    String text;
+
+    if (ratio < 100) {
+      color = Colors.green;
+      text = "안정적";
+    } else if (ratio < 200) {
+      color = Colors.orange;
+      text = "보통";
+    } else {
+      color = Colors.red;
+      text = "주의";
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Row(
+        children: [
+          Text(
+            "${ratio.toStringAsFixed(1)}% ",
+            style: TextStyle(color: color, fontWeight: FontWeight.bold, fontSize: 13),
+          ),
+          Text(
+            text,
+            style: TextStyle(color: color, fontWeight: FontWeight.normal, fontSize: 13),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // 하단 범례 아이템
+  Widget _buildLegendItem({
+    required String title,
+    required String value,
+    required Color color,
+    required CrossAxisAlignment align,
+  }) {
+    return Column(
+      crossAxisAlignment: align,
+      children: [
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 8, height: 8,
+              decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+            ),
+            const SizedBox(width: 6),
+            Text(title, style: TextStyle(color: Colors.grey[600], fontSize: 12)),
+          ],
+        ),
+        const SizedBox(height: 4),
+        Text(
+          value,
+          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 15),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/stock_detail/presentation/widget/financial_stability_card.dart
+++ b/lib/features/stock_detail/presentation/widget/financial_stability_card.dart
@@ -19,7 +19,10 @@ class FinancialStabilityData {
   });
 
   // 부채비율 계산 (부채 / 자본 * 100)
-  double get debtRatio => (totalLiabilitiesVal / totalEquityVal) * 100;
+  double get debtRatio {
+    if (totalEquityVal <= 0) return 0.0;  // 또는 적절한 기본값
+      return (totalLiabilitiesVal / totalEquityVal) * 100;
+    }
 }
 
 class FinancialStabilityCard extends StatelessWidget {

--- a/lib/features/stock_detail/presentation/widget/financial_summary_card.dart
+++ b/lib/features/stock_detail/presentation/widget/financial_summary_card.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+
+// 개별 재무 지표 데이터 모델
+class FinancialMetric {
+  final String name;
+  final String value;
+  final String evaluation;
+  final Color badgeColor;
+
+  const FinancialMetric({
+    required this.name,
+    required this.value,
+    required this.evaluation,
+    required this.badgeColor,
+  });
+}
+
+/// 종목 상세 - 재무 탭의 '재무 요약' 카드
+class FinancialSummaryCard extends StatelessWidget {
+  final List<FinancialMetric> metrics;
+
+  const FinancialSummaryCard({super.key, required this.metrics});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 20),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: const Color(0xFFE0E0E0)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text('재무 요약', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 16),
+          GridView.count(
+            crossAxisCount: 2, // 한 줄에 2개씩
+            shrinkWrap: true, // 내용의 크기에 맞게 높이 조절
+            physics: const NeverScrollableScrollPhysics(), // GridView 자체 스크롤 비활성화
+            childAspectRatio: 2.5, // 가로:세로 비율
+            mainAxisSpacing: 16, // 세로 간격
+            crossAxisSpacing: 16, // 가로 간격
+            children: metrics.map((metric) => _MetricTile(metric: metric)).toList(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 재무 지표 하나를 표시하는 타일 위젯
+// TODO 내부 로직으로 각각 값의 수치 범위에 따라 직접 평가와 색상을 결정하는 로직 만들기
+class _MetricTile extends StatelessWidget {
+  final FinancialMetric metric;
+
+  const _MetricTile({required this.metric});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(metric.name, style: TextStyle(fontSize: 13, color: Colors.grey[600])),
+        const SizedBox(height: 4),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.baseline,
+          textBaseline: TextBaseline.alphabetic,
+          children: [
+            Text(metric.value, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+            const SizedBox(width: 8),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),
+              decoration: BoxDecoration(
+                color: metric.badgeColor.withOpacity(0.15),
+                borderRadius: BorderRadius.circular(6),
+              ),
+              child: Text(
+                metric.evaluation,
+                style: TextStyle(
+                  color: metric.badgeColor,
+                  fontSize: 11,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/stock_detail/presentation/widget/financials_tab.dart
+++ b/lib/features/stock_detail/presentation/widget/financials_tab.dart
@@ -5,12 +5,20 @@ import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/perfo
 
 /// 종목 상세 페이지의 '재무' 탭 UI 전체를 담고 있는 위젯
 class FinancialsTab extends StatelessWidget {
-  const FinancialsTab({super.key});
+  final String stockName;
+  final String stockCode;
+
+  const FinancialsTab({
+    super.key,
+    required this.stockName,
+    required this.stockCode,
+  });
 
   @override
   Widget build(BuildContext context) {
-    // TODO: 실제 데이터 모델을 외부에서 전달받아야 합니다.
+    final theme = Theme.of(context);
 
+    // TODO: 실제 데이터 모델을 외부에서 전달받아야 합니다.
     final List<FinancialMetric> summaryMetrics = [
       const FinancialMetric(name: 'PER', value: '15.8배', evaluation: '보통', badgeColor: Colors.orange),
       const FinancialMetric(name: 'ROE', value: '9.7%', evaluation: '양호', badgeColor: Colors.green),
@@ -31,15 +39,10 @@ class FinancialsTab extends StatelessWidget {
       PerformanceDataPoint(period: '23.4Q', revenue: 489, operatingProfit: 64, netIncome: 55),
     ];
 
-    // 재무 상태 카드용 임시 데이터
     const stabilityData = FinancialStabilityData(
-      // 1. 화면에 글자로 보여줄 데이터 (단위 포함)
       totalAssetsStr: '4,567억',
       totalLiabilitiesStr: '2,989억',
       totalEquityStr: '1,578억',
-
-      // 2. 그래프와 비율 계산에 쓸 실제 숫자 데이터 (단위, 콤마 제외)
-      // 나중에 DB에서 가져올 때는 Long 타입을 double로 변환해서 넣으면 됨
       totalLiabilitiesVal: 2989,
       totalEquityVal: 1578,
     );
@@ -47,15 +50,47 @@ class FinancialsTab extends StatelessWidget {
     return ListView(
       padding: const EdgeInsets.symmetric(vertical: 16.0),
       children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20.0),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Text(
+                '재무',
+                style: theme.textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+              const Spacer(),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                decoration: BoxDecoration(
+                  color: theme.dividerColor.withOpacity(0.10),
+                  borderRadius: BorderRadius.circular(999),
+                ),
+                child: Text(
+                  '$stockName  $stockCode',
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: theme.colorScheme.onSurface.withOpacity(0.70),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 12),
+
         FinancialSummaryCard(metrics: summaryMetrics),
         const SizedBox(height: 16),
-        const PerformanceChartCard(
+
+        PerformanceChartCard(
           annualData: annualData,
           quarterlyData: quarterlyData,
         ),
         const SizedBox(height: 16),
-        // #3 재무 상태 카드 위젯 추가
-        const FinancialStabilityCard(data: stabilityData),
+
+        FinancialStabilityCard(data: stabilityData),
       ],
     );
   }

--- a/lib/features/stock_detail/presentation/widget/financials_tab.dart
+++ b/lib/features/stock_detail/presentation/widget/financials_tab.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/financial_stability_card.dart';
 import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/financial_summary_card.dart';
 import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/performance_chart_card.dart';
 
@@ -17,7 +18,6 @@ class FinancialsTab extends StatelessWidget {
       const FinancialMetric(name: '부채비율', value: '85%', evaluation: '안정적', badgeColor: Colors.green),
     ];
 
-    // [핵심 추가] 실적 분석 카드용 임시 데이터
     const annualData = [
       PerformanceDataPoint(period: '22년', revenue: 1792, operatingProfit: -92, netIncome: -110),
       PerformanceDataPoint(period: '23년', revenue: 1869, operatingProfit: 319, netIncome: 280),
@@ -31,22 +31,31 @@ class FinancialsTab extends StatelessWidget {
       PerformanceDataPoint(period: '23.4Q', revenue: 489, operatingProfit: 64, netIncome: 55),
     ];
 
+    // 재무 상태 카드용 임시 데이터
+    const stabilityData = FinancialStabilityData(
+      // 1. 화면에 글자로 보여줄 데이터 (단위 포함)
+      totalAssetsStr: '4,567억',
+      totalLiabilitiesStr: '2,989억',
+      totalEquityStr: '1,578억',
+
+      // 2. 그래프와 비율 계산에 쓸 실제 숫자 데이터 (단위, 콤마 제외)
+      // 나중에 DB에서 가져올 때는 Long 타입을 double로 변환해서 넣으면 됨
+      totalLiabilitiesVal: 2989,
+      totalEquityVal: 1578,
+    );
+
     return ListView(
       padding: const EdgeInsets.symmetric(vertical: 16.0),
       children: [
         FinancialSummaryCard(metrics: summaryMetrics),
         const SizedBox(height: 16),
-        //  #2 실적 분석 카드 위젯 추가
         const PerformanceChartCard(
           annualData: annualData,
           quarterlyData: quarterlyData,
         ),
         const SizedBox(height: 16),
-        // 3. 재무 상태 카드 (만들 예정)
-        const Padding(
-          padding: EdgeInsets.all(8.0),
-          child: Center(child: Text('#3 재무 상태 카드 영역')),
-        ),
+        // #3 재무 상태 카드 위젯 추가
+        const FinancialStabilityCard(data: stabilityData),
       ],
     );
   }

--- a/lib/features/stock_detail/presentation/widget/financials_tab.dart
+++ b/lib/features/stock_detail/presentation/widget/financials_tab.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/financial_summary_card.dart';
 
 /// 종목 상세 페이지의 '재무' 탭 UI 전체를 담고 있는 위젯
 class FinancialsTab extends StatelessWidget {
@@ -6,23 +7,30 @@ class FinancialsTab extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // TODO: 실제 데이터 모델을 외부에서 전달받아야 합니다.
+
+    // 1. 재무 요약 카드용 임시 데이터
+    final List<FinancialMetric> summaryMetrics = [
+      const FinancialMetric(name: 'PER', value: '15.8배', evaluation: '보통', badgeColor: Colors.orange),
+      const FinancialMetric(name: 'ROE', value: '9.7%', evaluation: '양호', badgeColor: Colors.green),
+      const FinancialMetric(name: '배당수익률', value: '2.1%', evaluation: '매력적', badgeColor: Colors.blue),
+      const FinancialMetric(name: '부채비율', value: '85%', evaluation: '안정적', badgeColor: Colors.green),
+    ];
+
     return ListView(
       padding: const EdgeInsets.symmetric(vertical: 16.0),
-      children: const [
-        // 1. 재무 요약 카드 (만들 예정)
-        Padding(
-          padding: EdgeInsets.all(8.0),
-          child: Center(child: Text('#1 재무 요약 카드 영역')),
-        ),
-        SizedBox(height: 16),
+      children: [
+        // [핵심 수정] #1 재무 요약 카드 위젯 추가
+        FinancialSummaryCard(metrics: summaryMetrics),
+        const SizedBox(height: 16),
         // 2. 실적 분석 그래프 카드 (만들 예정)
-        Padding(
+        const Padding(
           padding: EdgeInsets.all(8.0),
           child: Center(child: Text('#2 실적 분석 그래프 영역')),
         ),
-        SizedBox(height: 16),
+        const SizedBox(height: 16),
         // 3. 재무 상태 카드 (만들 예정)
-        Padding(
+        const Padding(
           padding: EdgeInsets.all(8.0),
           child: Center(child: Text('#3 재무 상태 카드 영역')),
         ),

--- a/lib/features/stock_detail/presentation/widget/financials_tab.dart
+++ b/lib/features/stock_detail/presentation/widget/financials_tab.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+/// 종목 상세 페이지의 '재무' 탭 UI 전체를 담고 있는 위젯
+class FinancialsTab extends StatelessWidget {
+  const FinancialsTab({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.symmetric(vertical: 16.0),
+      children: const [
+        // 1. 재무 요약 카드 (만들 예정)
+        Padding(
+          padding: EdgeInsets.all(8.0),
+          child: Center(child: Text('#1 재무 요약 카드 영역')),
+        ),
+        SizedBox(height: 16),
+        // 2. 실적 분석 그래프 카드 (만들 예정)
+        Padding(
+          padding: EdgeInsets.all(8.0),
+          child: Center(child: Text('#2 실적 분석 그래프 영역')),
+        ),
+        SizedBox(height: 16),
+        // 3. 재무 상태 카드 (만들 예정)
+        Padding(
+          padding: EdgeInsets.all(8.0),
+          child: Center(child: Text('#3 재무 상태 카드 영역')),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/stock_detail/presentation/widget/financials_tab.dart
+++ b/lib/features/stock_detail/presentation/widget/financials_tab.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/financial_summary_card.dart';
+import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/performance_chart_card.dart';
 
 /// 종목 상세 페이지의 '재무' 탭 UI 전체를 담고 있는 위젯
 class FinancialsTab extends StatelessWidget {
@@ -9,7 +10,6 @@ class FinancialsTab extends StatelessWidget {
   Widget build(BuildContext context) {
     // TODO: 실제 데이터 모델을 외부에서 전달받아야 합니다.
 
-    // 1. 재무 요약 카드용 임시 데이터
     final List<FinancialMetric> summaryMetrics = [
       const FinancialMetric(name: 'PER', value: '15.8배', evaluation: '보통', badgeColor: Colors.orange),
       const FinancialMetric(name: 'ROE', value: '9.7%', evaluation: '양호', badgeColor: Colors.green),
@@ -17,16 +17,29 @@ class FinancialsTab extends StatelessWidget {
       const FinancialMetric(name: '부채비율', value: '85%', evaluation: '안정적', badgeColor: Colors.green),
     ];
 
+    // [핵심 추가] 실적 분석 카드용 임시 데이터
+    const annualData = [
+      PerformanceDataPoint(period: '22년', revenue: 1792, operatingProfit: -92, netIncome: -110),
+      PerformanceDataPoint(period: '23년', revenue: 1869, operatingProfit: 319, netIncome: 280),
+      PerformanceDataPoint(period: '24년', revenue: 2339, operatingProfit: 157, netIncome: 120),
+    ];
+
+    const quarterlyData = [
+      PerformanceDataPoint(period: '23.1Q', revenue: 450, operatingProfit: 80, netIncome: 70),
+      PerformanceDataPoint(period: '23.2Q', revenue: 460, operatingProfit: 85, netIncome: 75),
+      PerformanceDataPoint(period: '23.3Q', revenue: 470, operatingProfit: 90, netIncome: 80),
+      PerformanceDataPoint(period: '23.4Q', revenue: 489, operatingProfit: 64, netIncome: 55),
+    ];
+
     return ListView(
       padding: const EdgeInsets.symmetric(vertical: 16.0),
       children: [
-        // [핵심 수정] #1 재무 요약 카드 위젯 추가
         FinancialSummaryCard(metrics: summaryMetrics),
         const SizedBox(height: 16),
-        // 2. 실적 분석 그래프 카드 (만들 예정)
-        const Padding(
-          padding: EdgeInsets.all(8.0),
-          child: Center(child: Text('#2 실적 분석 그래프 영역')),
+        //  #2 실적 분석 카드 위젯 추가
+        const PerformanceChartCard(
+          annualData: annualData,
+          quarterlyData: quarterlyData,
         ),
         const SizedBox(height: 16),
         // 3. 재무 상태 카드 (만들 예정)

--- a/lib/features/stock_detail/presentation/widget/performance_chart_card.dart
+++ b/lib/features/stock_detail/presentation/widget/performance_chart_card.dart
@@ -110,7 +110,7 @@ class _PerformanceChartCardState extends State<PerformanceChartCard> {
               data: data,
               valueSelector: (d) => d.netIncome,
               chartType: _ChartType.bar,
-              color: const Color(0xFFF2A23B), // 톤다운 오렌지
+              color: const Color(0xFF8098EA), // 톤다운 오렌지
             ),
           ),
         ],

--- a/lib/features/stock_detail/presentation/widget/performance_chart_card.dart
+++ b/lib/features/stock_detail/presentation/widget/performance_chart_card.dart
@@ -1,0 +1,515 @@
+import 'dart:math';
+import 'package:flutter/material.dart';
+
+class PerformanceDataPoint {
+  final String period;
+  final double revenue;
+  final double operatingProfit;
+  final double netIncome;
+
+  const PerformanceDataPoint({
+    required this.period,
+    required this.revenue,
+    required this.operatingProfit,
+    required this.netIncome,
+  });
+}
+
+class PerformanceChartCard extends StatefulWidget {
+  final List<PerformanceDataPoint> annualData;
+  final List<PerformanceDataPoint> quarterlyData;
+
+  const PerformanceChartCard({
+    super.key,
+    required this.annualData,
+    required this.quarterlyData,
+  });
+
+  @override
+  State<PerformanceChartCard> createState() => _PerformanceChartCardState();
+}
+
+class _PerformanceChartCardState extends State<PerformanceChartCard> {
+  bool _isAnnual = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final data = _isAnnual ? widget.annualData : widget.quarterlyData;
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 20),
+      padding: const EdgeInsets.fromLTRB(16, 14, 16, 16),
+      decoration: BoxDecoration(
+        color: theme.cardColor,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: theme.dividerColor.withOpacity(0.15)),
+        boxShadow: [
+          BoxShadow(
+            blurRadius: 18,
+            offset: const Offset(0, 8),
+            color: Colors.black.withOpacity(0.06),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 타이틀 + 토글
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                '실적 분석',
+                style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w800),
+              ),
+              _PillToggle(
+                left: '연간',
+                right: '분기',
+                isLeftSelected: _isAnnual,
+                onChanged: (isLeft) => setState(() => _isAnnual = isLeft),
+              ),
+            ],
+          ),
+          const SizedBox(height: 14),
+
+          // 섹션 1
+          _ChartSection(
+            title: '매출액',
+            subtitle: _isAnnual ? '연간(억원)' : '분기(억원)',
+            height: 160,
+            painter: _PerformanceChartPainter(
+              data: data,
+              valueSelector: (d) => d.revenue,
+              chartType: _ChartType.bar,
+              color: const Color(0xFF58B9CC), // 톤다운 시안
+            ),
+          ),
+          _SoftDivider(),
+
+          // 섹션 2
+          _ChartSection(
+            title: '영업이익',
+            subtitle: _isAnnual ? '연간(억원)' : '분기(억원)',
+            height: 160,
+            painter: _PerformanceChartPainter(
+              data: data,
+              valueSelector: (d) => d.operatingProfit,
+              chartType: _ChartType.line,
+              color: const Color(0xFF66B06A), // 톤다운 그린
+            ),
+          ),
+          _SoftDivider(),
+
+          // 섹션 3
+          _ChartSection(
+            title: '당기순이익',
+            subtitle: _isAnnual ? '연간(억원)' : '분기(억원)',
+            height: 160,
+            painter: _PerformanceChartPainter(
+              data: data,
+              valueSelector: (d) => d.netIncome,
+              chartType: _ChartType.bar,
+              color: const Color(0xFFF2A23B), // 톤다운 오렌지
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SoftDivider extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 14),
+      child: Divider(
+        height: 1,
+        thickness: 1,
+        color: theme.dividerColor.withOpacity(0.10),
+      ),
+    );
+  }
+}
+
+class _ChartSection extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final double height;
+  final CustomPainter painter;
+
+  const _ChartSection({
+    required this.title,
+    required this.subtitle,
+    required this.height,
+    required this.painter,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Text(
+              title,
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+            const SizedBox(width: 8),
+            Text(
+              subtitle,
+              style: theme.textTheme.labelMedium?.copyWith(
+                color: theme.hintColor.withOpacity(0.9),
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        SizedBox(
+          height: height,
+          width: double.infinity,
+          child: CustomPaint(
+            painter: painter,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// 토글: 목표 UI처럼 pill 느낌 (ToggleButtons보다 덜 투박)
+class _PillToggle extends StatelessWidget {
+  final String left;
+  final String right;
+  final bool isLeftSelected;
+  final ValueChanged<bool> onChanged;
+
+  const _PillToggle({
+    required this.left,
+    required this.right,
+    required this.isLeftSelected,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      height: 34,
+      padding: const EdgeInsets.all(3),
+      decoration: BoxDecoration(
+        color: theme.dividerColor.withOpacity(0.12),
+        borderRadius: BorderRadius.circular(10),
+      ),
+      child: Row(
+        children: [
+          _PillItem(
+            text: left,
+            selected: isLeftSelected,
+            onTap: () => onChanged(true),
+          ),
+          _PillItem(
+            text: right,
+            selected: !isLeftSelected,
+            onTap: () => onChanged(false),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PillItem extends StatelessWidget {
+  final String text;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _PillItem({
+    required this.text,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(8),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 160),
+        padding: const EdgeInsets.symmetric(horizontal: 14),
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: selected ? const Color(0xFF3B82F6) : Colors.transparent,
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Text(
+          text,
+          style: theme.textTheme.labelLarge?.copyWith(
+            fontWeight: FontWeight.w800,
+            color: selected ? Colors.white : theme.colorScheme.onSurface.withOpacity(0.75),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+enum _ChartType { bar, line }
+
+class _PerformanceChartPainter extends CustomPainter {
+  final List<PerformanceDataPoint> data;
+  final double Function(PerformanceDataPoint) valueSelector;
+  final _ChartType chartType;
+  final Color color;
+
+  _PerformanceChartPainter({
+    required this.data,
+    required this.valueSelector,
+    required this.chartType,
+    required this.color,
+  });
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (data.isEmpty) return;
+
+    // 차트 내부 패딩(라벨/축 때문에 필수)
+    const double topPad = 18;    // 값 라벨 공간
+    const double bottomPad = 22; // 기간 라벨 공간
+    const double sidePad = 6;
+
+    final chartRect = Rect.fromLTWH(
+      sidePad,
+      topPad,
+      size.width - sidePad * 2,
+      size.height - topPad - bottomPad,
+    );
+
+    final rawValues = data.map(valueSelector).toList();
+
+    final isBar = chartType == _ChartType.bar;
+    final isLine = chartType == _ChartType.line;
+
+    // ============================================================
+    // 요구사항 반영 스케일/플로팅 값
+    // 1) Bar: 음수여도 위로만(절댓값으로 높이 계산), 색만 회색
+    // 2) Line(영업이익): 음수면 0으로 클램프해서 아래로 내려가지 않게
+    // ============================================================
+    final plotValues = rawValues.map((v) {
+      if (isBar) return v.abs();         // bar는 절댓값으로 높이 계산
+      return max(0.0, v);               // line은 음수면 0으로 클램프
+    }).toList();
+
+    double maxPlot = plotValues.isEmpty ? 1.0 : plotValues.reduce(max);
+    if (maxPlot == 0) maxPlot = 1.0;
+    maxPlot *= 1.15; // 약간 여유
+
+    final baselineY = chartRect.bottom; // 항상 아래가 기준선(위로만 그림)
+
+    // 은은한 보조 그리드(2줄)
+    final gridPaint = Paint()
+      ..color = Colors.grey.withOpacity(0.10)
+      ..strokeWidth = 1;
+
+    for (int i = 1; i <= 2; i++) {
+      final y = chartRect.top + chartRect.height * (i / 3);
+      canvas.drawLine(
+        Offset(chartRect.left, y),
+        Offset(chartRect.right, y),
+        gridPaint,
+      );
+    }
+
+    // 기준선(하단)
+    final basePaint = Paint()
+      ..color = Colors.grey.withOpacity(0.20)
+      ..strokeWidth = 1;
+
+    canvas.drawLine(
+      Offset(chartRect.left, baselineY),
+      Offset(chartRect.right, baselineY),
+      basePaint,
+    );
+
+    final stepX = chartRect.width / data.length;
+    final barWidth = min(34.0, stepX * 0.55);
+
+    final linePaint = Paint()
+      ..color = color
+      ..strokeWidth = 2.6
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round;
+
+    final barPaint = Paint()..color = color;
+    final negBarPaint = Paint()..color = Colors.grey.withOpacity(0.35);
+
+    Path? linePath;
+
+    for (int i = 0; i < data.length; i++) {
+      final rawV = rawValues[i];     // 라벨은 원래 값(음수면 - 표시)
+      final plotV = plotValues[i];   // 그릴 때만 변환(절댓값/클램프)
+
+      final cx = chartRect.left + stepX * i + stepX / 2;
+
+      // plotV는 [0..maxPlot] 범위라고 가정
+      final y = baselineY - (plotV / maxPlot) * chartRect.height;
+
+      // 기간 라벨
+      _drawText(
+        canvas,
+        data[i].period,
+        Offset(cx, size.height - bottomPad + 4),
+        fontSize: 11,
+        fontWeight: FontWeight.w600,
+        color: Colors.black.withOpacity(0.55),
+      );
+
+      // 값 라벨
+      final valueLabel = _formatEok(rawV);
+
+      double rawLabelY;
+      Color labelColor = Colors.black.withOpacity(0.80);
+
+      if (isBar) {
+        // bar는 항상 막대 위쪽에 라벨
+        rawLabelY = y - 16;
+        if (rawV < 0) {
+          // 적자 표시(요구사항: 숫자에 - 붙여 표시) -> 이미 valueLabel이 - 포함
+          // 라벨 색은 그대로 두거나 약간 톤다운해도 됨(원하면 아래처럼)
+          labelColor = Colors.black.withOpacity(0.75);
+        }
+      } else {
+        // line: 음수면 선은 baseline에 붙지만 라벨은 아래로 살짝 내려서(적자 느낌)
+        if (rawV >= 0) {
+          rawLabelY = y - 16;
+        } else {
+          rawLabelY = baselineY + 6;
+          labelColor = Colors.black.withOpacity(0.70);
+        }
+      }
+
+      // 침범 방지 clamp (⚠️ clamp는 num 반환 -> toDouble 필수)
+      final minLabelY = chartRect.top + 2.0;
+      final maxLabelY = chartRect.bottom - 14.0;
+      final safeLabelY = rawLabelY.clamp(minLabelY, maxLabelY).toDouble();
+
+      _drawText(
+        canvas,
+        valueLabel,
+        Offset(cx, safeLabelY),
+        fontSize: 12,
+        fontWeight: FontWeight.w800,
+        color: labelColor,
+      );
+
+      if (isBar) {
+        // bar: 음수도 위로만 그리기(절댓값 plotV로 y 계산했기 때문에 자연스럽게 위로)
+        final rect = Rect.fromLTWH(
+          cx - barWidth / 2,
+          y,
+          barWidth,
+          (baselineY - y).clamp(0.0, chartRect.height),
+        );
+
+        canvas.drawRRect(
+          RRect.fromRectAndRadius(rect, const Radius.circular(6)),
+          rawV >= 0 ? barPaint : negBarPaint, // ✅ 음수면 회색
+        );
+      } else {
+        // line: 음수는 0으로 클램프되어 y가 baseline에 붙음
+        if (i == 0) {
+          linePath = Path()..moveTo(cx, y);
+        } else {
+          final prevPlotV = plotValues[i - 1];
+          final prevCx = chartRect.left + stepX * (i - 1) + stepX / 2;
+          final prevY = baselineY - (prevPlotV / maxPlot) * chartRect.height;
+
+          // 간단 스무딩
+          final midX = (prevCx + cx) / 2;
+          linePath!.quadraticBezierTo(prevCx, prevY, midX, (prevY + y) / 2);
+          linePath!.quadraticBezierTo(cx, y, cx, y);
+        }
+      }
+    }
+
+    // line fill (baseline까지)
+    if (isLine && linePath != null) {
+      final fillPath = Path.from(linePath!);
+      fillPath.lineTo(chartRect.right, baselineY);
+      fillPath.lineTo(chartRect.left, baselineY);
+      fillPath.close();
+
+      final fillPaint = Paint()
+        ..shader = LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [color.withOpacity(0.22), color.withOpacity(0.0)],
+        ).createShader(chartRect);
+
+      canvas.drawPath(fillPath, fillPaint);
+      canvas.drawPath(linePath!, linePaint);
+    }
+  }
+
+  String _formatEok(double v) {
+    final n = v.round(); // 음수면 - 유지
+    return '${_formatInt(n)}억';
+  }
+
+  String _formatInt(int n) {
+    final neg = n < 0;
+    final absStr = n.abs().toString();
+    final buf = StringBuffer();
+
+    for (int i = 0; i < absStr.length; i++) {
+      final posFromEnd = absStr.length - i;
+      buf.write(absStr[i]);
+      if (posFromEnd > 1 && posFromEnd % 3 == 1) buf.write(',');
+    }
+    return neg ? '-${buf.toString()}' : buf.toString();
+  }
+
+  void _drawText(
+      Canvas canvas,
+      String text,
+      Offset center, {
+        required double fontSize,
+        required FontWeight fontWeight,
+        required Color color,
+      }) {
+    final tp = TextPainter(
+      text: TextSpan(
+        text: text,
+        style: TextStyle(
+          color: color,
+          fontSize: fontSize,
+          fontWeight: fontWeight,
+        ),
+      ),
+      textDirection: TextDirection.ltr,
+      textAlign: TextAlign.center,
+    )..layout();
+
+    tp.paint(canvas, Offset(center.dx - tp.width / 2, center.dy));
+  }
+
+  @override
+  bool shouldRepaint(covariant _PerformanceChartPainter oldDelegate) {
+    return oldDelegate.data != data ||
+        oldDelegate.chartType != chartType ||
+        oldDelegate.color != color;
+  }
+}

--- a/lib/features/stock_detail/presentation/widget/performance_chart_card.dart
+++ b/lib/features/stock_detail/presentation/widget/performance_chart_card.dart
@@ -43,12 +43,12 @@ class _PerformanceChartCardState extends State<PerformanceChartCard> {
       decoration: BoxDecoration(
         color: theme.cardColor,
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: theme.dividerColor.withOpacity(0.15)),
+        border: Border.all(color: theme.dividerColor.withAlpha((0.15 * 255).round())),
         boxShadow: [
           BoxShadow(
             blurRadius: 18,
             offset: const Offset(0, 8),
-            color: Colors.black.withOpacity(0.06),
+            color: Colors.black.withAlpha((0.06 * 255).round()),
           ),
         ],
       ),
@@ -59,9 +59,9 @@ class _PerformanceChartCardState extends State<PerformanceChartCard> {
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
-              Text(
+              const Text(
                 '실적 분석',
-                style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w800),
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
               ),
               _PillToggle(
                 left: '연간',
@@ -128,7 +128,7 @@ class _SoftDivider extends StatelessWidget {
       child: Divider(
         height: 1,
         thickness: 1,
-        color: theme.dividerColor.withOpacity(0.10),
+        color: theme.dividerColor.withAlpha((0.10 * 255).round()),
       ),
     );
   }
@@ -167,7 +167,7 @@ class _ChartSection extends StatelessWidget {
             Text(
               subtitle,
               style: theme.textTheme.labelMedium?.copyWith(
-                color: theme.hintColor.withOpacity(0.9),
+                color: theme.hintColor.withAlpha((0.9 * 255).round()),
                 fontWeight: FontWeight.w600,
               ),
             ),
@@ -208,7 +208,7 @@ class _PillToggle extends StatelessWidget {
       height: 34,
       padding: const EdgeInsets.all(3),
       decoration: BoxDecoration(
-        color: theme.dividerColor.withOpacity(0.12),
+        color: theme.dividerColor.withAlpha((0.12 * 255).round()),
         borderRadius: BorderRadius.circular(10),
       ),
       child: Row(
@@ -259,7 +259,7 @@ class _PillItem extends StatelessWidget {
           text,
           style: theme.textTheme.labelLarge?.copyWith(
             fontWeight: FontWeight.w800,
-            color: selected ? Colors.white : theme.colorScheme.onSurface.withOpacity(0.75),
+            color: selected ? Colors.white : theme.colorScheme.onSurface.withAlpha((0.75 * 255).round()),
           ),
         ),
       ),
@@ -286,9 +286,8 @@ class _PerformanceChartPainter extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     if (data.isEmpty) return;
 
-    // 차트 내부 패딩(라벨/축 때문에 필수)
-    const double topPad = 18;    // 값 라벨 공간
-    const double bottomPad = 22; // 기간 라벨 공간
+    const double topPad = 18;
+    const double bottomPad = 22;
     const double sidePad = 6;
 
     final chartRect = Rect.fromLTWH(
@@ -299,29 +298,22 @@ class _PerformanceChartPainter extends CustomPainter {
     );
 
     final rawValues = data.map(valueSelector).toList();
-
     final isBar = chartType == _ChartType.bar;
     final isLine = chartType == _ChartType.line;
 
-    // ============================================================
-    // 요구사항 반영 스케일/플로팅 값
-    // 1) Bar: 음수여도 위로만(절댓값으로 높이 계산), 색만 회색
-    // 2) Line(영업이익): 음수면 0으로 클램프해서 아래로 내려가지 않게
-    // ============================================================
     final plotValues = rawValues.map((v) {
-      if (isBar) return v.abs();         // bar는 절댓값으로 높이 계산
-      return max(0.0, v);               // line은 음수면 0으로 클램프
+      if (isBar) return v.abs();
+      return max(0.0, v);
     }).toList();
 
     double maxPlot = plotValues.isEmpty ? 1.0 : plotValues.reduce(max);
     if (maxPlot == 0) maxPlot = 1.0;
-    maxPlot *= 1.15; // 약간 여유
+    maxPlot *= 1.15;
 
-    final baselineY = chartRect.bottom; // 항상 아래가 기준선(위로만 그림)
+    final baselineY = chartRect.bottom;
 
-    // 은은한 보조 그리드(2줄)
     final gridPaint = Paint()
-      ..color = Colors.grey.withOpacity(0.10)
+      ..color = Colors.grey.withAlpha((0.10 * 255).round())
       ..strokeWidth = 1;
 
     for (int i = 1; i <= 2; i++) {
@@ -333,9 +325,8 @@ class _PerformanceChartPainter extends CustomPainter {
       );
     }
 
-    // 기준선(하단)
     final basePaint = Paint()
-      ..color = Colors.grey.withOpacity(0.20)
+      ..color = Colors.grey.withAlpha((0.20 * 255).round())
       ..strokeWidth = 1;
 
     canvas.drawLine(
@@ -354,54 +345,44 @@ class _PerformanceChartPainter extends CustomPainter {
       ..strokeCap = StrokeCap.round;
 
     final barPaint = Paint()..color = color;
-    final negBarPaint = Paint()..color = Colors.grey.withOpacity(0.35);
+    final negBarPaint = Paint()..color = Colors.grey.withAlpha((0.35 * 255).round());
 
     Path? linePath;
 
     for (int i = 0; i < data.length; i++) {
-      final rawV = rawValues[i];     // 라벨은 원래 값(음수면 - 표시)
-      final plotV = plotValues[i];   // 그릴 때만 변환(절댓값/클램프)
-
+      final rawV = rawValues[i];
+      final plotV = plotValues[i];
       final cx = chartRect.left + stepX * i + stepX / 2;
-
-      // plotV는 [0..maxPlot] 범위라고 가정
       final y = baselineY - (plotV / maxPlot) * chartRect.height;
 
-      // 기간 라벨
       _drawText(
         canvas,
         data[i].period,
-        Offset(cx, size.height - bottomPad + 4),
+        Offset(cx, baselineY + 10),
         fontSize: 11,
         fontWeight: FontWeight.w600,
-        color: Colors.black.withOpacity(0.55),
+        color: Colors.black.withAlpha((0.55 * 255).round()),
       );
 
-      // 값 라벨
       final valueLabel = _formatEok(rawV);
-
       double rawLabelY;
-      Color labelColor = Colors.black.withOpacity(0.80);
+      Color labelColor = Colors.black.withAlpha((0.80 * 255).round());
 
+      // 라벨의 Y좌표를 조정하여 막대/선에 더 가깝게 만듭니다.
       if (isBar) {
-        // bar는 항상 막대 위쪽에 라벨
-        rawLabelY = y - 16;
+        rawLabelY = y - 10; // 기존 -16에서 변경
         if (rawV < 0) {
-          // 적자 표시(요구사항: 숫자에 - 붙여 표시) -> 이미 valueLabel이 - 포함
-          // 라벨 색은 그대로 두거나 약간 톤다운해도 됨(원하면 아래처럼)
-          labelColor = Colors.black.withOpacity(0.75);
+          labelColor = Colors.black.withAlpha((0.75 * 255).round());
         }
       } else {
-        // line: 음수면 선은 baseline에 붙지만 라벨은 아래로 살짝 내려서(적자 느낌)
         if (rawV >= 0) {
-          rawLabelY = y - 16;
+          rawLabelY = y - 10; // 기존 -16에서 변경
         } else {
           rawLabelY = baselineY + 6;
-          labelColor = Colors.black.withOpacity(0.70);
+          labelColor = Colors.black.withAlpha((0.70 * 255).round());
         }
       }
 
-      // 침범 방지 clamp (⚠️ clamp는 num 반환 -> toDouble 필수)
       final minLabelY = chartRect.top + 2.0;
       final maxLabelY = chartRect.bottom - 14.0;
       final safeLabelY = rawLabelY.clamp(minLabelY, maxLabelY).toDouble();
@@ -416,38 +397,32 @@ class _PerformanceChartPainter extends CustomPainter {
       );
 
       if (isBar) {
-        // bar: 음수도 위로만 그리기(절댓값 plotV로 y 계산했기 때문에 자연스럽게 위로)
         final rect = Rect.fromLTWH(
           cx - barWidth / 2,
           y,
           barWidth,
           (baselineY - y).clamp(0.0, chartRect.height),
         );
-
         canvas.drawRRect(
           RRect.fromRectAndRadius(rect, const Radius.circular(6)),
-          rawV >= 0 ? barPaint : negBarPaint, // ✅ 음수면 회색
+          rawV >= 0 ? barPaint : negBarPaint,
         );
       } else {
-        // line: 음수는 0으로 클램프되어 y가 baseline에 붙음
         if (i == 0) {
           linePath = Path()..moveTo(cx, y);
         } else {
           final prevPlotV = plotValues[i - 1];
           final prevCx = chartRect.left + stepX * (i - 1) + stepX / 2;
           final prevY = baselineY - (prevPlotV / maxPlot) * chartRect.height;
-
-          // 간단 스무딩
           final midX = (prevCx + cx) / 2;
           linePath!.quadraticBezierTo(prevCx, prevY, midX, (prevY + y) / 2);
-          linePath!.quadraticBezierTo(cx, y, cx, y);
+          linePath.quadraticBezierTo(cx, y, cx, y);
         }
       }
     }
 
-    // line fill (baseline까지)
     if (isLine && linePath != null) {
-      final fillPath = Path.from(linePath!);
+      final fillPath = Path.from(linePath);
       fillPath.lineTo(chartRect.right, baselineY);
       fillPath.lineTo(chartRect.left, baselineY);
       fillPath.close();
@@ -456,16 +431,16 @@ class _PerformanceChartPainter extends CustomPainter {
         ..shader = LinearGradient(
           begin: Alignment.topCenter,
           end: Alignment.bottomCenter,
-          colors: [color.withOpacity(0.22), color.withOpacity(0.0)],
+          colors: [color.withAlpha((255 * 0.22).round()), color.withAlpha(0)],
         ).createShader(chartRect);
 
       canvas.drawPath(fillPath, fillPaint);
-      canvas.drawPath(linePath!, linePaint);
+      canvas.drawPath(linePath, linePaint);
     }
   }
 
   String _formatEok(double v) {
-    final n = v.round(); // 음수면 - 유지
+    final n = v.round();
     return '${_formatInt(n)}억';
   }
 
@@ -490,26 +465,17 @@ class _PerformanceChartPainter extends CustomPainter {
         required FontWeight fontWeight,
         required Color color,
       }) {
-    final tp = TextPainter(
-      text: TextSpan(
-        text: text,
-        style: TextStyle(
-          color: color,
-          fontSize: fontSize,
-          fontWeight: fontWeight,
-        ),
-      ),
-      textDirection: TextDirection.ltr,
+    final textPainter = TextPainter(
+      text: TextSpan(text: text, style: TextStyle(fontSize: fontSize, fontWeight: fontWeight, color: color)),
       textAlign: TextAlign.center,
-    )..layout();
+      textDirection: TextDirection.ltr,
+    )..layout(minWidth: 0, maxWidth: 60);
 
-    tp.paint(canvas, Offset(center.dx - tp.width / 2, center.dy));
+    textPainter.paint(canvas, center - Offset(textPainter.width / 2, textPainter.height / 2));
   }
 
   @override
   bool shouldRepaint(covariant _PerformanceChartPainter oldDelegate) {
-    return oldDelegate.data != data ||
-        oldDelegate.chartType != chartType ||
-        oldDelegate.color != color;
+    return true;
   }
 }


### PR DESCRIPTION
## 📌 Issue number and Link
  closed #17 

## 📝 Changes
- 재무 탭 UI 구현: 종목 상세 페이지에 재무 탭의 전체 UI 구조를 완성했습니다.
- 컴포넌트 분리: 재무 탭을 아래의 3가지 주요 카드 위젯으로 분리하여 구현했습니다.
  - FinancialSummaryCard: PER, ROE 등 핵심 지표와 평가 뱃지를 표시합니다.
  - PerformanceChartCard: 연간/분기 선택 기능을 포함하며, 매출액(막대), 영업이익(선), 당기순이익(막대) 차트를 각각 그립니다.
  - FinancialStabilityCard: 자산, 부채, 자본 구성 및 부채비율을 시각적으로 보여줍니다.

## 🧐 서버 구현 참고 사항
- FinancialsTab: 페이지 자체 헤더에 종목명/코드를 표시하기 위해 stockName, stockCode 데이터가 필요합니다.
- FinancialSummaryCard: PER, ROE, 배당수익률, 부채비율의 수치 데이터가 필요합니다. 양호/보통 등의 평가는 클라이언트에서 수치 범위를 기준으로 처리할 예정임
- PerformanceChartCard: annualData와 quarterlyData 두 종류의 리스트가 필요하며, 각 데이터 포인트는 period, revenue, operatingProfit, netIncome 값을 포함함.
- FinancialStabilityCard: 스택 바와 수치 표시를 위해 부채총계, 자본총계의 수치 데이터가 필요함

## 🔎 PR Type

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot
<img width="419" height="870" alt="image" src="https://github.com/user-attachments/assets/2832224e-735e-41a4-b830-5496b3dbc63d" />
<img width="417" height="861" alt="image" src="https://github.com/user-attachments/assets/b26de2e2-ce86-43b5-aea8-502ae30a9f95" />
<img width="448" height="372" alt="image" src="https://github.com/user-attachments/assets/7497b1ec-26ce-4682-afc0-b98ffd6e96fc" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 주식 상세 페이지에 재무 탭 추가
  * 핵심 재무 지표(PER, ROE, 배당수익률 등) 요약 카드 표시
  * 부채비율을 시각화한 재무 안정성 카드 제공
  * 연간 및 분기별 실적 추이(매출, 영업이익, 당기순이익) 차트 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->