### PR TITLE
[FEATURE] 종목 상세 조회 - 뉴스/공시 UI 구현

### DIFF
--- a/lib/core/widget/pill_toggle.dart
+++ b/lib/core/widget/pill_toggle.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+
+/// 토글: 목표 UI처럼 pill 느낌 (ToggleButtons보다 덜 투박)
+class PillToggle extends StatelessWidget {
+  final String left;
+  final String right;
+  final bool isLeftSelected;
+  final ValueChanged<bool> onChanged;
+
+  const PillToggle({
+    super.key,
+    required this.left,
+    required this.right,
+    required this.isLeftSelected,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Material(
+      color: theme.dividerColor.withAlpha((0.12 * 255).round()),
+      borderRadius: BorderRadius.circular(10),
+      child: Container(
+        height: 34,
+        padding: const EdgeInsets.all(3),
+        child: Row(
+          mainAxisSize: MainAxisSize.min, // Row가 필요한 만큼만 공간을 차지하도록 설정
+          children: [
+            _PillItem(
+              text: left,
+              selected: isLeftSelected,
+              onTap: () => onChanged(true),
+            ),
+            _PillItem(
+              text: right,
+              selected: !isLeftSelected,
+              onTap: () => onChanged(false),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PillItem extends StatelessWidget {
+  final String text;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _PillItem({
+    required this.text,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    // CodeRabbit Review 반영: InkWell을 Material로 감싸야 함
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(8),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 160),
+          padding: const EdgeInsets.symmetric(horizontal: 14),
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: selected ? const Color(0xFF3B82F6) : Colors.transparent,
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Text(
+            text,
+            style: theme.textTheme.labelLarge?.copyWith(
+              fontWeight: FontWeight.w800,
+              color: selected
+                  ? Colors.white
+                  : theme.colorScheme.onSurface.withAlpha((0.75 * 255).round()),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/stock_detail/data/model/news_announcement_models.dart
+++ b/lib/features/stock_detail/data/model/news_announcement_models.dart
@@ -1,0 +1,85 @@
+/// 백엔드 PageDTO 대응
+class PageDTO<T> {
+  final List<T> content;
+  final int currentPage;
+  final int size;
+  final bool hasNext;
+  final int totalContentCount;
+
+  PageDTO({
+    required this.content,
+    required this.currentPage,
+    required this.size,
+    required this.hasNext,
+    required this.totalContentCount,
+  });
+
+  factory PageDTO.fromJson(
+    Map<String, dynamic> json,
+    T Function(dynamic json) fromJsonT,
+  ) {
+    return PageDTO<T>(
+      content: (json['content'] as List<dynamic>).map((e) => fromJsonT(e)).toList(),
+      currentPage: json['currentPage'] as int,
+      size: json['size'] as int,
+      hasNext: json['hasNext'] as bool,
+      totalContentCount: json['totalContentCount'] as int,
+    );
+  }
+}
+
+/// 백엔드 NewsResponseItemDTO 대응
+class NewsResponseItem {
+  final String title;
+  final String link;
+  final String pubDate;
+
+  // 클라이언트 UI용 추가 필드 (API 연동 전까지 Mock용, 추후 필요 시 제거 or 별도 관리)
+  final String source; 
+  final String? thumbnail;
+
+  NewsResponseItem({
+    required this.title,
+    required this.link,
+    required this.pubDate,
+    this.source = 'Unknown',
+    this.thumbnail,
+  });
+
+  factory NewsResponseItem.fromJson(Map<String, dynamic> json) {
+    return NewsResponseItem(
+      title: json['title'] as String,
+      link: json['link'] as String,
+      pubDate: json['pubDate'] as String,
+      source: json['source'] ?? 'Unknown', // API에는 없지만 UI용
+      thumbnail: json['thumbnail'], // API에는 없지만 UI용
+    );
+  }
+}
+
+/// 백엔드 DisclosureItemResponseDTO 대응
+class DisclosureItemResponse {
+  final String reportName; // 공시 제목
+  final String receiptNo;  // 접수번호
+  final String submitter;  // 제출인
+  final String date;       // 접수일자 (YYYYMMDD)
+
+  // 클라이언트 UI용 추가 필드 (유형 태그 파싱 로직 등은 추후 추가)
+  String get tag => '[공시]'; // 임시 태그 로직
+
+  DisclosureItemResponse({
+    required this.reportName,
+    required this.receiptNo,
+    required this.submitter,
+    required this.date,
+  });
+
+  factory DisclosureItemResponse.fromJson(Map<String, dynamic> json) {
+    return DisclosureItemResponse(
+      reportName: json['reportName'] as String,
+      receiptNo: json['receiptNo'] as String,
+      submitter: json['submitter'] as String,
+      date: json['date'] as String,
+    );
+  }
+}

--- a/lib/features/stock_detail/presentation/stock_detail_page.dart
+++ b/lib/features/stock_detail/presentation/stock_detail_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/daily_price_tab.dart';
 import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/financials_tab.dart';
 import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/overview_tab.dart';
+import 'package:ssogssog_flutter/features/stock_detail/presentation/widget/news_announcements_tab.dart';
 
 class StockDetailPage extends StatefulWidget {
   final String stockCode;
@@ -38,7 +39,7 @@ class _StockDetailPageState extends State<StockDetailPage> {
             stockName: stockName,
             stockCode: widget.stockCode,
           ),
-          const Center(child: Text('뉴스/공시 탭 콘텐츠')),
+          const NewsAnnouncementsTab(),
         ],
       ),
       bottomNavigationBar: _buildBottomNavigationBar(),

--- a/lib/features/stock_detail/presentation/widget/news_announcements_tab.dart
+++ b/lib/features/stock_detail/presentation/widget/news_announcements_tab.dart
@@ -1,0 +1,259 @@
+import 'package:flutter/material.dart';
+import 'package:ssogssog_flutter/core/widget/pill_toggle.dart';
+import 'package:ssogssog_flutter/features/stock_detail/data/model/news_announcement_models.dart';
+
+class NewsAnnouncementsTab extends StatefulWidget {
+  const NewsAnnouncementsTab({super.key});
+
+  @override
+  State<NewsAnnouncementsTab> createState() => _NewsAnnouncementsTabState();
+}
+
+class _NewsAnnouncementsTabState extends State<NewsAnnouncementsTab> {
+  // true: 뉴스 탭, false: 공시 탭
+  bool _isNews = true;
+
+  // [Mock Data] 뉴스 데이터
+  final List<NewsResponseItem> _newsList = [
+    NewsResponseItem(
+      title: '큐로홀딩스, 3분기 영업이익 전년비 15% 증가... "IT 부품 호조"',
+      link: 'https://news.naver.com/...',
+      pubDate: '1시간 전',
+      source: '이데일리',
+      thumbnail: 'https://via.placeholder.com/80',
+    ),
+    NewsResponseItem(
+      title: '[특징주] 큐로홀딩스, 신규 계약 체결 소식에 강세',
+      link: 'https://news.naver.com/...',
+      pubDate: '3시간 전',
+      source: '한국경제',
+      thumbnail: '',
+    ),
+    NewsResponseItem(
+      title: '반도체 부품주 동반 상승... 큐로홀딩스도 5%대 급등',
+      link: 'https://news.naver.com/...',
+      pubDate: '5시간 전',
+      source: '매일경제',
+      thumbnail: 'https://via.placeholder.com/80',
+    ),
+    NewsResponseItem(
+      title: '큐로홀딩스 "주주가치 제고 위해 자사주 매입 검토"',
+      link: 'https://news.naver.com/...',
+      pubDate: '어제',
+      source: '아시아경제',
+      thumbnail: '',
+    ),
+    NewsResponseItem(
+      title: '글로벌 공급망 이슈 완화 기대감... 관련주 주목',
+      link: 'https://news.naver.com/...',
+      pubDate: '2023.12.20',
+      source: '파이낸셜뉴스',
+      thumbnail: 'https://via.placeholder.com/80',
+    ),
+  ];
+
+  // [Mock Data] 공시 데이터
+  final List<DisclosureItemResponse> _announcementList = [
+    DisclosureItemResponse(
+      reportName: '단일판매ㆍ공급계약체결',
+      receiptNo: '20231224...',
+      submitter: '큐로홀딩스',
+      date: '2023.12.24',
+    ),
+    DisclosureItemResponse(
+      reportName: '분기보고서 (2023.09)',
+      receiptNo: '20231114...',
+      submitter: '큐로홀딩스',
+      date: '2023.11.14',
+    ),
+    DisclosureItemResponse(
+      reportName: '주주총회소집결의',
+      receiptNo: '20231010...',
+      submitter: '큐로홀딩스',
+      date: '2023.10.10',
+    ),
+    DisclosureItemResponse(
+      reportName: '최대주주등소유주식변동신고서',
+      receiptNo: '20230928...',
+      submitter: '큐로홀딩스',
+      date: '2023.09.28',
+    ),
+    DisclosureItemResponse(
+      reportName: '풍문 또는 보도에 대한 해명',
+      receiptNo: '20230915...',
+      submitter: '큐로홀딩스',
+      date: '2023.09.15',
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        _buildHeader(),
+        Expanded(
+          child: _isNews ? _buildNewsList() : _buildAnnouncementList(),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildHeader() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 16.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Row(
+            children: [
+              const Text(
+                '뉴스/공시',
+                style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                _isNews ? '최신 뉴스' : '전자 공시',
+                style: const TextStyle(fontSize: 12, color: Colors.grey),
+              ),
+            ],
+          ),
+          PillToggle(
+            left: '뉴스',
+            right: '공시',
+            isLeftSelected: _isNews,
+            onChanged: (isLeft) => setState(() => _isNews = isLeft),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNewsList() {
+    return ListView.separated(
+      padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 8.0),
+      itemCount: _newsList.length,
+      separatorBuilder: (context, index) => const Divider(height: 1, color: Color(0xFFEEEEEE)),
+      itemBuilder: (context, index) {
+        final item = _newsList[index];
+        final hasImage = item.thumbnail?.isNotEmpty ?? false;
+
+        return InkWell(
+          onTap: () {
+            // TODO: 뉴스 상세 페이지 또는 웹뷰로 이동
+          },
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 16.0),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        item.title,
+                        style: const TextStyle(
+                          fontSize: 15,
+                          fontWeight: FontWeight.w600,
+                          height: 1.3,
+                        ),
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      const SizedBox(height: 8),
+                      Row(
+                        children: [
+                          Text(
+                            item.source,
+                            style: TextStyle(fontSize: 12, color: Colors.grey[600]),
+                          ),
+                          const SizedBox(width: 8),
+                          Container(width: 1, height: 10, color: Colors.grey[300]),
+                          const SizedBox(width: 8),
+                          Text(
+                            item.pubDate,
+                            style: TextStyle(fontSize: 12, color: Colors.grey[500]),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+                if (hasImage) ...[
+                  const SizedBox(width: 16),
+                  Container(
+                    width: 72,
+                    height: 54,
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(8),
+                      color: Colors.grey[200], // 이미지 로딩 전/실패 시 배경색
+                      image: DecorationImage(
+                        image: NetworkImage(item.thumbnail!),
+                        fit: BoxFit.cover,
+                      ),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildAnnouncementList() {
+    return ListView.separated(
+      padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 8.0),
+      itemCount: _announcementList.length,
+      separatorBuilder: (context, index) => const Divider(height: 1, color: Color(0xFFEEEEEE)),
+      itemBuilder: (context, index) {
+        final item = _announcementList[index];
+
+        return InkWell(
+          onTap: () {
+            // TODO: 공시 상세 페이지 또는 다트(DART) 웹뷰로 이동
+          },
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 16.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        item.tag,
+                        style: const TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.bold,
+                          color: Color(0xFF55A4ED), // 앱 메인 컬러
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        item.reportName,
+                        style: const TextStyle(
+                          fontSize: 15,
+                          fontWeight: FontWeight.w500,
+                          height: 1.3,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                  ),
+                ),
+                Text(
+                  item.date,
+                  style: TextStyle(fontSize: 12, color: Colors.grey[500]),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/stock_detail/presentation/widget/performance_chart_card.dart
+++ b/lib/features/stock_detail/presentation/widget/performance_chart_card.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 import 'package:flutter/material.dart';
+import 'package:ssogssog_flutter/core/widget/pill_toggle.dart';
 
 class PerformanceDataPoint {
   final String period;
@@ -63,7 +64,7 @@ class _PerformanceChartCardState extends State<PerformanceChartCard> {
                 '실적 분석',
                 style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
               ),
-              _PillToggle(
+              PillToggle(
                 left: '연간',
                 right: '분기',
                 isLeftSelected: _isAnnual,
@@ -196,85 +197,7 @@ class _ChartSection extends StatelessWidget {
 }
 
 /// 토글: 목표 UI처럼 pill 느낌 (ToggleButtons보다 덜 투박)
-class _PillToggle extends StatelessWidget {
-  final String left;
-  final String right;
-  final bool isLeftSelected;
-  final ValueChanged<bool> onChanged;
 
-  const _PillToggle({
-    required this.left,
-    required this.right,
-    required this.isLeftSelected,
-    required this.onChanged,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
-    return Material(
-      color: theme.dividerColor.withAlpha((0.12 * 255).round()),
-      borderRadius: BorderRadius.circular(10),
-      child: Container(
-          height: 34,
-          padding: const EdgeInsets.all(3),
-      child: Row(
-        children: [
-          _PillItem(
-            text: left,
-            selected: isLeftSelected,
-            onTap: () => onChanged(true),
-          ),
-          _PillItem(
-            text: right,
-            selected: !isLeftSelected,
-            onTap: () => onChanged(false),
-          ),
-        ],
-      ),
-      ),
-    );
-  }
-}
-
-class _PillItem extends StatelessWidget {
-  final String text;
-  final bool selected;
-  final VoidCallback onTap;
-
-  const _PillItem({
-    required this.text,
-    required this.selected,
-    required this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
-    return InkWell(
-      onTap: onTap,
-      borderRadius: BorderRadius.circular(8),
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 160),
-        padding: const EdgeInsets.symmetric(horizontal: 14),
-        alignment: Alignment.center,
-        decoration: BoxDecoration(
-          color: selected ? const Color(0xFF3B82F6) : Colors.transparent,
-          borderRadius: BorderRadius.circular(8),
-        ),
-        child: Text(
-          text,
-          style: theme.textTheme.labelLarge?.copyWith(
-            fontWeight: FontWeight.w800,
-            color: selected ? Colors.white : theme.colorScheme.onSurface.withAlpha((0.75 * 255).round()),
-          ),
-        ),
-      ),
-    );
-  }
-}
 
 enum _ChartType { bar, line }
 


### PR DESCRIPTION
## 📌 Issue number and Link
  closed #22 

## ✏️ Summary
 뉴스/공시 탭 구현: 최신 뉴스(썸네일 포함)와 전자공시 리스트 UI를 개발했습니다.


## 📝 Changes
- news_announcement_tab 생성
- API 연동용 모델 생성
- PillToggle 생성

## 🔎 PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring
- [ ] infrastructure related changes (CI/CD, Build)
- [ ] Documentation content changes

## 📸 Screenshot


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 주가 상세 페이지의 뉴스/공시 탭에 실제 데이터 표시 기능 추가
  * 뉴스와 공시 정보 간 토글 전환 기능 추가
  * 뉴스 항목에 제목, 출처, 발행일, 썸네일 표시
  * 공시 항목에 리포트명, 접수번호, 제출자, 날짜 표시

* **리팩토링**
  * 재사용 가능한 토글 버튼 컴포넌트로 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->